### PR TITLE
🔧 Fix YAML syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,19 +97,17 @@ jobs:
             # For docs project, check if pyproject.toml exists, if not create a minimal one
             if [[ ! -f "$PROJECT/pyproject.toml" ]]; then
               echo "📝 Creating pyproject.toml for docs project"
-              cat > $PROJECT/pyproject.toml << EOF
-[project]
-name = "docs"
-version = "$NEW_VERSION"
-description = "Documentation for MySwiftAgent"
-authors = [
-    {name = "MySwiftAgent Team", email = "noreply@example.com"},
-]
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-EOF
+              echo '[project]' > $PROJECT/pyproject.toml
+              echo 'name = "docs"' >> $PROJECT/pyproject.toml
+              echo "version = \"$NEW_VERSION\"" >> $PROJECT/pyproject.toml
+              echo 'description = "Documentation for MySwiftAgent"' >> $PROJECT/pyproject.toml
+              echo 'authors = [' >> $PROJECT/pyproject.toml
+              echo '    {name = "MySwiftAgent Team", email = "noreply@example.com"},' >> $PROJECT/pyproject.toml
+              echo ']' >> $PROJECT/pyproject.toml
+              echo '' >> $PROJECT/pyproject.toml
+              echo '[build-system]' >> $PROJECT/pyproject.toml
+              echo 'requires = ["hatchling"]' >> $PROJECT/pyproject.toml
+              echo 'build-backend = "hatchling.build"' >> $PROJECT/pyproject.toml
             else
               # Update existing version
               sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" $PROJECT/pyproject.toml


### PR DESCRIPTION
## 🐛 Issue

Fix critical YAML syntax error in `release.yml` workflow that was causing workflow failures after the docs project integration.

## 🔍 Root Cause

**Error Location**: `.github/workflows/release.yml` lines 101-102

**Technical Issue**: 
- YAML parser was interpreting HEREDOC content as YAML structure
- The `<< EOF` syntax within YAML caused parsing conflicts
- Content like `[project]` was mistakenly parsed as YAML keys expecting `:`

```yaml
# Problematic code that caused the error:
cat > $PROJECT/pyproject.toml << EOF
[project]          # ← YAML parser misinterpreted this as YAML key
name = "docs"      # ← Expected ':' here, causing syntax error
```

## 🔧 Solution

Replace HEREDOC syntax with individual echo statements to eliminate YAML parsing conflicts:

```bash
# Fixed approach:
echo '[project]' > $PROJECT/pyproject.toml
echo 'name = "docs"' >> $PROJECT/pyproject.toml
echo "version = \"$NEW_VERSION\"" >> $PROJECT/pyproject.toml
# ... continued for all lines
```

## ✅ Benefits

- **🛡️ YAML Safety**: Eliminates parser confusion completely
- **🎯 Functionality Preserved**: pyproject.toml generation works identically  
- **📖 Readability**: Each line is clearly separated and easier to understand
- **🚀 Reliability**: Prevents future workflow failures

## 🧪 Validation

- [x] **YAML Syntax**: Validated with Python YAML parser
- [x] **Workflow Execution**: Currently running successfully
- [x] **Functionality**: pyproject.toml generation logic preserved
- [x] **Backwards Compatibility**: No impact on existing myscheduler/jobqueue projects

## 📋 Files Changed

- `.github/workflows/release.yml` - Fixed HEREDOC syntax in docs project handling

This fix ensures the docs project integration works reliably without breaking existing release workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)