### PR TITLE
🔧 Force GitHub Actions workflow name recognition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release Quality Assurance
 
+# Multi-project release workflow with automated version management
 on:
   push:
     branches:


### PR DESCRIPTION
## 🎯 Purpose

Force GitHub Actions to properly recognize and display the workflow name "Release Quality Assurance" instead of the file path ".github/workflows/release.yml".

## 🔍 Issue

GitHub Actions UI is displaying the workflow as `.github/workflows/release.yml` instead of the properly defined name `Release Quality Assurance`. This typically occurs due to:

1. **GitHub internal caching** of workflow metadata
2. **Previous YAML syntax errors** that prevented proper name parsing
3. **Workflow recognition issues** after recent fixes

## 🛠️ Solution

Added a descriptive comment to the workflow file to trigger GitHub Actions to:
- Re-parse the workflow file
- Update internal workflow metadata  
- Properly display the workflow name in the UI

## 📋 Changes

- Add descriptive comment: `# Multi-project release workflow with automated version management`
- No functional changes to workflow logic
- Purely cosmetic fix for UI display

## ✅ Expected Outcome

After this PR is merged, the workflow should appear as "Release Quality Assurance" in:
- GitHub Actions UI workflow list
- Workflow run displays  
- API responses

🤖 Generated with [Claude Code](https://claude.ai/code)