### PR TITLE
🔧 Fix auto-release workflow for commonUI project

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -31,7 +31,7 @@ jobs:
           CHANGED_PROJECTS=""
           HAS_CHANGES="false"
 
-          for project in myscheduler jobqueue docs; do
+          for project in myscheduler jobqueue docs commonUI; do
             if [[ -d "$project" ]]; then
               CHANGES=$(git diff HEAD~1 HEAD --name-only | grep "^$project/" || true)
               if [[ -n "$CHANGES" ]]; then


### PR DESCRIPTION
## 📋 Summary

- Fix auto-release workflow to include commonUI in project monitoring
- Resolves issue where commonUI releases were skipped due to missing project detection

## 🐛 Problem

The "Create Releases and Tags" job was being skipped when commonUI changes were merged to main because:
- `auto-release.yml` only monitored `myscheduler`, `jobqueue`, and `docs` projects
- `commonUI` was not included in the monitoring list
- This caused `has_changes=false` and skipped the release job

## ✅ Solution

- Added `commonUI` to the monitored projects list in `.github/workflows/auto-release.yml`
- Now commonUI changes will trigger automatic tag and release creation

## 🧪 Test Plan

- [x] Verified the issue by analyzing PR #33 merge behavior  
- [x] Confirmed commonUI was missing from monitoring list
- [x] Applied fix and committed to staging branch
- [ ] Verify fix works on next commonUI change after merge

## 📦 Impact

- Enables automatic versioning and releases for commonUI project
- Consistent release workflow across all projects (myscheduler, jobqueue, docs, commonUI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)