### PR TITLE
🔧 Fix auto-release workflow to detect expertAgent changes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -38,7 +38,7 @@ jobs:
           HAS_CHANGES="false"
           PROJECT_COUNT=0
 
-          for project in myscheduler jobqueue docs commonUI; do
+          for project in myscheduler jobqueue docs commonUI expertAgent; do
             if [[ -d "$project" ]]; then
               CHANGES=$(git diff HEAD~1 HEAD --name-only | grep "^$project/" || true)
               if [[ -n "$CHANGES" ]]; then


### PR DESCRIPTION
## 概要

auto-release.yml ワークフローが expertAgent プロジェクトの変更を検出できるように修正しました。

## 問題

PR #46 (expertAgent v0.1.1) が main にマージされた際、タグが作成されませんでした。

**原因**: auto-release.yml のプロジェクト検出リストに expertAgent が含まれていなかった

## 修正内容

- `.github/workflows/auto-release.yml` の41行目に expertAgent を追加

```diff
- for project in myscheduler jobqueue docs commonUI; do
+ for project in myscheduler jobqueue docs commonUI expertAgent; do
```

## 検証

この修正により、今後 expertAgent の変更が main にマージされた際、自動的にタグと GitHub Release が作成されます。

## 影響範囲

- expertAgent プロジェクトの自動リリース機能が正常に動作するようになる
- 他のプロジェクト (myscheduler, jobqueue, docs, commonUI) への影響なし

## 次のステップ

この修正マージ後、expertAgent のバージョンを 0.1.2 に上げて再度リリースフローを実行し、タグ作成が正常に動作することを確認します。

🤖 Generated with [Claude Code](https://claude.ai/code)