### PR TITLE
chore(expertAgent): sync version to 0.2.1 to match staging

### DIFF
--- a/expertAgent/pyproject.toml
+++ b/expertAgent/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["app"]
 
 [project]
 name = "expertAgent"
-version = "0.2.0"
+version = "0.2.1"
 description = "Expert Agent Service for MySwiftAgent"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## 概要

staging ブランチと develop ブランチのバージョン同期。

## 問題

- **staging**: expertAgent v0.2.1 (PR #74 でリリース済み)
- **develop**: expertAgent v0.2.0

この差異により、PR #77 (develop → staging) で conflict が発生しています。

## 解決策

develop の expertAgent/pyproject.toml のバージョンを v0.2.1 に更新し、staging と同期させます。

## 変更内容

- `expertAgent/pyproject.toml`: version = "0.2.0" → "0.2.1"

## 影響範囲

- ✅ バージョン番号のみの変更
- ✅ コード変更なし
- ✅ staging との同期が完了

## 次のステップ

このPRをマージ後、PR #77 の conflict が自動的に解消されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)