### PR TITLE
fix(ci): Add Valkey service container to Integration Tests job

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -152,6 +152,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, detect-changes]
     if: needs.detect-changes.outputs.myscheduler == 'true' || needs.detect-changes.outputs.jobqueue == 'true' || needs.detect-changes.outputs.expertAgent == 'true' || needs.detect-changes.outputs.commonUI == 'true'
+    services:
+      valkey:
+        image: valkey/valkey:latest
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       matrix:
         project:


### PR DESCRIPTION
## Summary

- Integration Tests ジョブに Valkey サービスコンテナ設定を追加
- 22個のValkey関連テストの失敗を修正
- 既存の Test Suite ジョブと同一の設定を使用

## Changes

`.github/workflows/cd-develop.yml` に以下を追加:

```yaml
services:
  valkey:
    image: valkey/valkey:latest
    ports:
      - 6379:6379
    options: >-
      --health-cmd "valkey-cli ping"
      --health-interval 10s
      --health-timeout 5s
      --health-retries 5
```

## Test plan

- [ ] CI全体が成功（緑色）
- [ ] Integration Tests ジョブが正常に開始
- [ ] Valkey サービスコンテナが起動
- [ ] 22個のValkeyテストが全てPASSED

## Related

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)