### PR TITLE
feat(expertAgent): add Valkey integration to JobCreationStateManager (#239)

### DIFF
--- a/expertAgent/app/services/job_creation_state.py
+++ b/expertAgent/app/services/job_creation_state.py
@@ -1,16 +1,27 @@
 """Job creation state management service.
 
-This module provides in-memory state management for async job creation.
-Tracks job creation progress, status, and results.
+This module provides 2-layer cache state management for async job creation.
+L1: In-memory cache for fast access
+L2: Valkey (Redis-compatible) for persistence
+
+Issue #239: JobCreationStateManager Valkey integration.
 """
 
 import logging
+import warnings
 from datetime import datetime
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel
 
+if TYPE_CHECKING:
+    from app.services.valkey_client import ValkeyClient
+
 logger = logging.getLogger(__name__)
+
+# Default TTL for Valkey cache: 24 hours
+DEFAULT_TTL_SECONDS = 86400
+DEFAULT_KEY_PREFIX = "job:creation:"
 
 
 class JobCreationStatus(BaseModel):
@@ -27,32 +38,170 @@ class JobCreationStatus(BaseModel):
 
 
 class JobCreationStateManager:
-    """In-memory job creation state manager.
+    """2-layer cache job creation state manager.
 
-    Stores job creation status for tracking progress.
+    L1: In-memory cache for fast access
+    L2: Valkey (Redis-compatible) for persistence
+
+    Supports graceful degradation when Valkey is unavailable.
     Thread-safe for concurrent access.
+
+    Args:
+        valkey_client: Optional ValkeyClient for L2 cache
+        ttl_seconds: TTL for Valkey cache in seconds (default: 24 hours)
+        key_prefix: Prefix for Valkey keys (default: "job:creation:")
     """
 
-    def __init__(self) -> None:
-        """Initialize state manager with empty storage."""
-        self._storage: dict[str, JobCreationStatus] = {}
+    def __init__(
+        self,
+        valkey_client: Optional["ValkeyClient"] = None,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        key_prefix: str = DEFAULT_KEY_PREFIX,
+    ) -> None:
+        """Initialize state manager with optional Valkey client.
 
-    def create_job(self, job_id: str) -> None:
-        """Create new job creation tracking entry.
+        Args:
+            valkey_client: Optional ValkeyClient for L2 cache
+            ttl_seconds: TTL for Valkey cache in seconds
+            key_prefix: Prefix for Valkey keys
+        """
+        self._storage: dict[str, JobCreationStatus] = {}
+        self._valkey_client: Optional["ValkeyClient"] = valkey_client
+        self._valkey_connected: bool = False
+        self._ttl_seconds: int = ttl_seconds
+        self._key_prefix: str = key_prefix
+
+    def _get_valkey_key(self, job_id: str) -> str:
+        """Get Valkey key for job ID.
+
+        Args:
+            job_id: Job ID
+
+        Returns:
+            Valkey key with prefix
+        """
+        return f"{self._key_prefix}{job_id}"
+
+    async def connect_valkey(self) -> None:
+        """Connect to Valkey server.
+
+        Handles connection failure gracefully (degradation to L1 only).
+        """
+        if self._valkey_client is None:
+            logger.debug("No Valkey client configured, using L1 cache only")
+            self._valkey_connected = False
+            return
+
+        try:
+            await self._valkey_client.connect()
+            self._valkey_connected = True
+            logger.info("Connected to Valkey for job creation state persistence")
+        except Exception as e:
+            logger.warning(f"Failed to connect to Valkey, degrading to L1 only: {e}")
+            self._valkey_connected = False
+
+    async def disconnect_valkey(self) -> None:
+        """Disconnect from Valkey server."""
+        if self._valkey_client is not None and self._valkey_connected:
+            try:
+                await self._valkey_client.disconnect()
+                logger.info("Disconnected from Valkey")
+            except Exception as e:
+                logger.warning(f"Error disconnecting from Valkey: {e}")
+            finally:
+                self._valkey_connected = False
+
+    async def _write_to_valkey(self, job_id: str, status: JobCreationStatus) -> None:
+        """Write status to Valkey (L2 cache).
+
+        Handles write failure gracefully.
+
+        Args:
+            job_id: Job ID
+            status: Job creation status
+        """
+        if not self._valkey_connected or self._valkey_client is None:
+            return
+
+        try:
+            key = self._get_valkey_key(job_id)
+            data = status.model_dump(mode="json")
+            await self._valkey_client.set(key, data, ttl=self._ttl_seconds)
+            logger.debug(f"Wrote job {job_id} status to Valkey")
+        except Exception as e:
+            logger.warning(f"Failed to write job {job_id} to Valkey: {e}")
+
+    async def _read_from_valkey(self, job_id: str) -> Optional[JobCreationStatus]:
+        """Read status from Valkey (L2 cache).
+
+        Handles read failure gracefully.
+
+        Args:
+            job_id: Job ID
+
+        Returns:
+            JobCreationStatus if found, None otherwise
+        """
+        if not self._valkey_connected or self._valkey_client is None:
+            return None
+
+        try:
+            key = self._get_valkey_key(job_id)
+            data = await self._valkey_client.get(key)
+            if data is None:
+                return None
+
+            # Deserialize and populate L1 cache
+            status = JobCreationStatus.model_validate(data)
+            self._storage[job_id] = status
+            logger.debug(f"Loaded job {job_id} status from Valkey to L1 cache")
+            return status
+        except Exception as e:
+            logger.warning(f"Failed to read job {job_id} from Valkey: {e}")
+            return None
+
+    async def get_status_async(self, job_id: str) -> Optional[JobCreationStatus]:
+        """Get job creation status with 2-layer cache lookup.
+
+        Checks L1 (memory) first, then L2 (Valkey) if not found.
+
+        Args:
+            job_id: Job ID
+
+        Returns:
+            JobCreationStatus if found, None otherwise
+        """
+        # L1 cache hit
+        if job_id in self._storage:
+            return self._storage[job_id]
+
+        # L1 miss, try L2 (Valkey)
+        return await self._read_from_valkey(job_id)
+
+    async def create_job_async(self, job_id: str) -> None:
+        """Create new job creation tracking entry (async version).
+
+        Writes to both L1 and L2 cache.
 
         Args:
             job_id: Unique job ID
         """
-        self._storage[job_id] = JobCreationStatus(
+        status = JobCreationStatus(
             job_id=job_id,
             status="creating",
             progress=0,
             start_time=datetime.now(),
         )
+        self._storage[job_id] = status
         logger.info(f"Created job creation tracking for job_id={job_id}")
 
-    def update_progress(self, job_id: str, progress: int) -> None:
-        """Update job creation progress.
+        # Write to L2 (Valkey)
+        await self._write_to_valkey(job_id, status)
+
+    async def update_progress_async(self, job_id: str, progress: int) -> None:
+        """Update job creation progress (async version).
+
+        Writes to both L1 and L2 cache.
 
         Args:
             job_id: Job ID
@@ -65,13 +214,18 @@ class JobCreationStateManager:
         self._storage[job_id].progress = progress
         logger.debug(f"Updated job {job_id} progress to {progress}%")
 
-    def mark_completed(
+        # Write to L2 (Valkey)
+        await self._write_to_valkey(job_id, self._storage[job_id])
+
+    async def mark_completed_async(
         self,
         job_id: str,
         job_master_id: Optional[str] = None,
         result: Optional[dict[str, Any]] = None,
     ) -> None:
-        """Mark job creation as completed.
+        """Mark job creation as completed (async version).
+
+        Writes to both L1 and L2 cache.
 
         Args:
             job_id: Job ID
@@ -89,8 +243,13 @@ class JobCreationStateManager:
         self._storage[job_id].result = result
         logger.info(f"Marked job {job_id} as completed")
 
-    def mark_failed(self, job_id: str, error_message: str) -> None:
-        """Mark job creation as failed.
+        # Write to L2 (Valkey)
+        await self._write_to_valkey(job_id, self._storage[job_id])
+
+    async def mark_failed_async(self, job_id: str, error_message: str) -> None:
+        """Mark job creation as failed (async version).
+
+        Writes to both L1 and L2 cache.
 
         Args:
             job_id: Job ID
@@ -105,8 +264,116 @@ class JobCreationStateManager:
         self._storage[job_id].error_message = error_message
         logger.error(f"Marked job {job_id} as failed: {error_message}")
 
+        # Write to L2 (Valkey)
+        await self._write_to_valkey(job_id, self._storage[job_id])
+
+    # ----- Backward compatible sync methods (deprecated) -----
+
+    def create_job(self, job_id: str) -> None:
+        """Create new job creation tracking entry.
+
+        .. deprecated::
+            Use :meth:`create_job_async` instead for 2-layer cache support.
+
+        Args:
+            job_id: Unique job ID
+        """
+        warnings.warn(
+            "create_job() is deprecated, use create_job_async() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._storage[job_id] = JobCreationStatus(
+            job_id=job_id,
+            status="creating",
+            progress=0,
+            start_time=datetime.now(),
+        )
+        logger.info(f"Created job creation tracking for job_id={job_id}")
+
+    def update_progress(self, job_id: str, progress: int) -> None:
+        """Update job creation progress.
+
+        .. deprecated::
+            Use :meth:`update_progress_async` instead for 2-layer cache support.
+
+        Args:
+            job_id: Job ID
+            progress: Progress percentage (0-100)
+        """
+        warnings.warn(
+            "update_progress() is deprecated, use update_progress_async() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if job_id not in self._storage:
+            logger.warning(f"Job ID {job_id} not found in state manager")
+            return
+
+        self._storage[job_id].progress = progress
+        logger.debug(f"Updated job {job_id} progress to {progress}%")
+
+    def mark_completed(
+        self,
+        job_id: str,
+        job_master_id: Optional[str] = None,
+        result: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Mark job creation as completed.
+
+        .. deprecated::
+            Use :meth:`mark_completed_async` instead for 2-layer cache support.
+
+        Args:
+            job_id: Job ID
+            job_master_id: Optional job master ID
+            result: Optional result data
+        """
+        warnings.warn(
+            "mark_completed() is deprecated, use mark_completed_async() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if job_id not in self._storage:
+            logger.warning(f"Job ID {job_id} not found in state manager")
+            return
+
+        self._storage[job_id].status = "completed"
+        self._storage[job_id].progress = 100
+        self._storage[job_id].end_time = datetime.now()
+        self._storage[job_id].job_master_id = job_master_id
+        self._storage[job_id].result = result
+        logger.info(f"Marked job {job_id} as completed")
+
+    def mark_failed(self, job_id: str, error_message: str) -> None:
+        """Mark job creation as failed.
+
+        .. deprecated::
+            Use :meth:`mark_failed_async` instead for 2-layer cache support.
+
+        Args:
+            job_id: Job ID
+            error_message: Error message
+        """
+        warnings.warn(
+            "mark_failed() is deprecated, use mark_failed_async() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if job_id not in self._storage:
+            logger.warning(f"Job ID {job_id} not found in state manager")
+            return
+
+        self._storage[job_id].status = "failed"
+        self._storage[job_id].end_time = datetime.now()
+        self._storage[job_id].error_message = error_message
+        logger.error(f"Marked job {job_id} as failed: {error_message}")
+
     def get_status(self, job_id: str) -> Optional[JobCreationStatus]:
         """Get job creation status.
+
+        .. deprecated::
+            Use :meth:`get_status_async` instead for 2-layer cache support.
 
         Args:
             job_id: Job ID
@@ -114,10 +381,17 @@ class JobCreationStateManager:
         Returns:
             JobCreationStatus if found, None otherwise
         """
+        warnings.warn(
+            "get_status() is deprecated, use get_status_async() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._storage.get(job_id)
 
     def cleanup_old_jobs(self, max_age_seconds: int = 3600) -> None:
         """Remove old completed/failed jobs from storage.
+
+        Note: This only cleans L1 cache. Valkey entries expire via TTL.
 
         Args:
             max_age_seconds: Maximum age in seconds (default: 1 hour)

--- a/expertAgent/app/services/job_creation_state.py
+++ b/expertAgent/app/services/job_creation_state.py
@@ -5,12 +5,18 @@ L1: In-memory cache for fast access
 L2: Valkey (Redis-compatible) for persistence
 
 Issue #239: JobCreationStateManager Valkey integration.
+
+Refactored for:
+- DRY: Extracted common patterns (job lookup, Valkey availability check)
+- Single Responsibility: Separated status update logic
+- Consistent Logging: Cache hit/miss and connection status logging
 """
 
 import logging
 import warnings
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 from pydantic import BaseModel
 
@@ -22,6 +28,34 @@ logger = logging.getLogger(__name__)
 # Default TTL for Valkey cache: 24 hours
 DEFAULT_TTL_SECONDS = 86400
 DEFAULT_KEY_PREFIX = "job:creation:"
+
+# Type variable for generic return types in decorators
+T = TypeVar("T")
+
+
+def deprecated_sync_method(async_method_name: str) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator to mark sync methods as deprecated with consistent warnings.
+
+    Args:
+        async_method_name: Name of the async method to recommend instead.
+
+    Returns:
+        Decorator function that adds deprecation warning.
+    """
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            warnings.warn(
+                f"{func.__name__}() is deprecated, use {async_method_name}() instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 class JobCreationStatus(BaseModel):
@@ -71,6 +105,8 @@ class JobCreationStateManager:
         self._ttl_seconds: int = ttl_seconds
         self._key_prefix: str = key_prefix
 
+    # ----- Private Helper Methods (DRY principle) -----
+
     def _get_valkey_key(self, job_id: str) -> str:
         """Get Valkey key for job ID.
 
@@ -82,22 +118,101 @@ class JobCreationStateManager:
         """
         return f"{self._key_prefix}{job_id}"
 
+    def _is_valkey_available(self) -> bool:
+        """Check if Valkey is available for operations.
+
+        Returns:
+            True if Valkey client is configured and connected
+        """
+        return self._valkey_connected and self._valkey_client is not None
+
+    def _get_job_or_log_warning(self, job_id: str) -> Optional[JobCreationStatus]:
+        """Get job from L1 cache or log warning if not found.
+
+        Args:
+            job_id: Job ID
+
+        Returns:
+            JobCreationStatus if found, None otherwise (with warning logged)
+        """
+        if job_id not in self._storage:
+            logger.warning(f"Job ID {job_id} not found in state manager")
+            return None
+        return self._storage[job_id]
+
+    def _create_initial_status(self, job_id: str) -> JobCreationStatus:
+        """Create initial job creation status.
+
+        Args:
+            job_id: Job ID
+
+        Returns:
+            New JobCreationStatus with 'creating' status
+        """
+        return JobCreationStatus(
+            job_id=job_id,
+            status="creating",
+            progress=0,
+            start_time=datetime.now(),
+        )
+
+    def _update_status_completed(
+        self,
+        status: JobCreationStatus,
+        job_master_id: Optional[str] = None,
+        result: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Update status to completed (mutates in place).
+
+        Args:
+            status: Status to update
+            job_master_id: Optional job master ID
+            result: Optional result data
+        """
+        status.status = "completed"
+        status.progress = 100
+        status.end_time = datetime.now()
+        status.job_master_id = job_master_id
+        status.result = result
+
+    def _update_status_failed(
+        self, status: JobCreationStatus, error_message: str
+    ) -> None:
+        """Update status to failed (mutates in place).
+
+        Args:
+            status: Status to update
+            error_message: Error message
+        """
+        status.status = "failed"
+        status.end_time = datetime.now()
+        status.error_message = error_message
+
+    # ----- Connection Management -----
+
     async def connect_valkey(self) -> None:
         """Connect to Valkey server.
 
         Handles connection failure gracefully (degradation to L1 only).
+        Logs connection status for observability.
         """
         if self._valkey_client is None:
-            logger.debug("No Valkey client configured, using L1 cache only")
+            logger.debug(
+                "Valkey connection: skipped (no client configured, L1 cache only)"
+            )
             self._valkey_connected = False
             return
 
         try:
             await self._valkey_client.connect()
             self._valkey_connected = True
-            logger.info("Connected to Valkey for job creation state persistence")
+            logger.info(
+                "Valkey connection: success - L2 cache enabled for job state persistence"
+            )
         except Exception as e:
-            logger.warning(f"Failed to connect to Valkey, degrading to L1 only: {e}")
+            logger.warning(
+                f"Valkey connection: failed - degrading to L1 only. Error: {e}"
+            )
             self._valkey_connected = False
 
     async def disconnect_valkey(self) -> None:
@@ -105,36 +220,40 @@ class JobCreationStateManager:
         if self._valkey_client is not None and self._valkey_connected:
             try:
                 await self._valkey_client.disconnect()
-                logger.info("Disconnected from Valkey")
+                logger.info("Valkey connection: disconnected")
             except Exception as e:
-                logger.warning(f"Error disconnecting from Valkey: {e}")
+                logger.warning(f"Valkey disconnect: error occurred - {e}")
             finally:
                 self._valkey_connected = False
+
+    # ----- L2 Cache Operations -----
 
     async def _write_to_valkey(self, job_id: str, status: JobCreationStatus) -> None:
         """Write status to Valkey (L2 cache).
 
-        Handles write failure gracefully.
+        Handles write failure gracefully with consistent logging.
 
         Args:
             job_id: Job ID
             status: Job creation status
         """
-        if not self._valkey_connected or self._valkey_client is None:
+        if not self._is_valkey_available():
+            logger.debug(f"L2 write: skipped for job {job_id} (Valkey unavailable)")
             return
 
         try:
             key = self._get_valkey_key(job_id)
             data = status.model_dump(mode="json")
-            await self._valkey_client.set(key, data, ttl=self._ttl_seconds)
-            logger.debug(f"Wrote job {job_id} status to Valkey")
+            # _is_valkey_available check above guarantees client is not None
+            await self._valkey_client.set(key, data, ttl=self._ttl_seconds)  # type: ignore[union-attr]
+            logger.debug(f"L2 write: success for job {job_id}")
         except Exception as e:
-            logger.warning(f"Failed to write job {job_id} to Valkey: {e}")
+            logger.warning(f"L2 write: failed for job {job_id} - {e}")
 
     async def _read_from_valkey(self, job_id: str) -> Optional[JobCreationStatus]:
         """Read status from Valkey (L2 cache).
 
-        Handles read failure gracefully.
+        Handles read failure gracefully with cache hit/miss logging.
 
         Args:
             job_id: Job ID
@@ -142,28 +261,34 @@ class JobCreationStateManager:
         Returns:
             JobCreationStatus if found, None otherwise
         """
-        if not self._valkey_connected or self._valkey_client is None:
+        if not self._is_valkey_available():
+            logger.debug(f"L2 read: skipped for job {job_id} (Valkey unavailable)")
             return None
 
         try:
             key = self._get_valkey_key(job_id)
-            data = await self._valkey_client.get(key)
+            # _is_valkey_available check above guarantees client is not None
+            data = await self._valkey_client.get(key)  # type: ignore[union-attr]
             if data is None:
+                logger.debug(f"L2 cache miss: job {job_id} not found in Valkey")
                 return None
 
             # Deserialize and populate L1 cache
             status = JobCreationStatus.model_validate(data)
             self._storage[job_id] = status
-            logger.debug(f"Loaded job {job_id} status from Valkey to L1 cache")
+            logger.debug(f"L2 cache hit: loaded job {job_id} from Valkey to L1")
             return status
         except Exception as e:
-            logger.warning(f"Failed to read job {job_id} from Valkey: {e}")
+            logger.warning(f"L2 read: failed for job {job_id} - {e}")
             return None
+
+    # ----- Async Public API (Primary) -----
 
     async def get_status_async(self, job_id: str) -> Optional[JobCreationStatus]:
         """Get job creation status with 2-layer cache lookup.
 
         Checks L1 (memory) first, then L2 (Valkey) if not found.
+        Logs cache hit/miss for observability.
 
         Args:
             job_id: Job ID
@@ -173,9 +298,11 @@ class JobCreationStateManager:
         """
         # L1 cache hit
         if job_id in self._storage:
+            logger.debug(f"L1 cache hit: job {job_id}")
             return self._storage[job_id]
 
         # L1 miss, try L2 (Valkey)
+        logger.debug(f"L1 cache miss: job {job_id}, checking L2")
         return await self._read_from_valkey(job_id)
 
     async def create_job_async(self, job_id: str) -> None:
@@ -186,12 +313,7 @@ class JobCreationStateManager:
         Args:
             job_id: Unique job ID
         """
-        status = JobCreationStatus(
-            job_id=job_id,
-            status="creating",
-            progress=0,
-            start_time=datetime.now(),
-        )
+        status = self._create_initial_status(job_id)
         self._storage[job_id] = status
         logger.info(f"Created job creation tracking for job_id={job_id}")
 
@@ -207,15 +329,15 @@ class JobCreationStateManager:
             job_id: Job ID
             progress: Progress percentage (0-100)
         """
-        if job_id not in self._storage:
-            logger.warning(f"Job ID {job_id} not found in state manager")
+        status = self._get_job_or_log_warning(job_id)
+        if status is None:
             return
 
-        self._storage[job_id].progress = progress
+        status.progress = progress
         logger.debug(f"Updated job {job_id} progress to {progress}%")
 
         # Write to L2 (Valkey)
-        await self._write_to_valkey(job_id, self._storage[job_id])
+        await self._write_to_valkey(job_id, status)
 
     async def mark_completed_async(
         self,
@@ -232,19 +354,15 @@ class JobCreationStateManager:
             job_master_id: Optional job master ID
             result: Optional result data
         """
-        if job_id not in self._storage:
-            logger.warning(f"Job ID {job_id} not found in state manager")
+        status = self._get_job_or_log_warning(job_id)
+        if status is None:
             return
 
-        self._storage[job_id].status = "completed"
-        self._storage[job_id].progress = 100
-        self._storage[job_id].end_time = datetime.now()
-        self._storage[job_id].job_master_id = job_master_id
-        self._storage[job_id].result = result
+        self._update_status_completed(status, job_master_id, result)
         logger.info(f"Marked job {job_id} as completed")
 
         # Write to L2 (Valkey)
-        await self._write_to_valkey(job_id, self._storage[job_id])
+        await self._write_to_valkey(job_id, status)
 
     async def mark_failed_async(self, job_id: str, error_message: str) -> None:
         """Mark job creation as failed (async version).
@@ -255,20 +373,30 @@ class JobCreationStateManager:
             job_id: Job ID
             error_message: Error message
         """
-        if job_id not in self._storage:
-            logger.warning(f"Job ID {job_id} not found in state manager")
+        status = self._get_job_or_log_warning(job_id)
+        if status is None:
             return
 
-        self._storage[job_id].status = "failed"
-        self._storage[job_id].end_time = datetime.now()
-        self._storage[job_id].error_message = error_message
+        self._update_status_failed(status, error_message)
         logger.error(f"Marked job {job_id} as failed: {error_message}")
 
         # Write to L2 (Valkey)
-        await self._write_to_valkey(job_id, self._storage[job_id])
+        await self._write_to_valkey(job_id, status)
 
     # ----- Backward compatible sync methods (deprecated) -----
+    # These methods use the decorator and helper functions to reduce duplication
 
+    def _create_job_impl(self, job_id: str) -> None:
+        """Implementation of create_job without deprecation warning.
+
+        Args:
+            job_id: Unique job ID
+        """
+        status = self._create_initial_status(job_id)
+        self._storage[job_id] = status
+        logger.info(f"Created job creation tracking for job_id={job_id}")
+
+    @deprecated_sync_method("create_job_async")
     def create_job(self, job_id: str) -> None:
         """Create new job creation tracking entry.
 
@@ -278,19 +406,9 @@ class JobCreationStateManager:
         Args:
             job_id: Unique job ID
         """
-        warnings.warn(
-            "create_job() is deprecated, use create_job_async() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self._storage[job_id] = JobCreationStatus(
-            job_id=job_id,
-            status="creating",
-            progress=0,
-            start_time=datetime.now(),
-        )
-        logger.info(f"Created job creation tracking for job_id={job_id}")
+        self._create_job_impl(job_id)
 
+    @deprecated_sync_method("update_progress_async")
     def update_progress(self, job_id: str, progress: int) -> None:
         """Update job creation progress.
 
@@ -301,18 +419,14 @@ class JobCreationStateManager:
             job_id: Job ID
             progress: Progress percentage (0-100)
         """
-        warnings.warn(
-            "update_progress() is deprecated, use update_progress_async() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if job_id not in self._storage:
-            logger.warning(f"Job ID {job_id} not found in state manager")
+        status = self._get_job_or_log_warning(job_id)
+        if status is None:
             return
 
-        self._storage[job_id].progress = progress
+        status.progress = progress
         logger.debug(f"Updated job {job_id} progress to {progress}%")
 
+    @deprecated_sync_method("mark_completed_async")
     def mark_completed(
         self,
         job_id: str,
@@ -329,22 +443,14 @@ class JobCreationStateManager:
             job_master_id: Optional job master ID
             result: Optional result data
         """
-        warnings.warn(
-            "mark_completed() is deprecated, use mark_completed_async() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if job_id not in self._storage:
-            logger.warning(f"Job ID {job_id} not found in state manager")
+        status = self._get_job_or_log_warning(job_id)
+        if status is None:
             return
 
-        self._storage[job_id].status = "completed"
-        self._storage[job_id].progress = 100
-        self._storage[job_id].end_time = datetime.now()
-        self._storage[job_id].job_master_id = job_master_id
-        self._storage[job_id].result = result
+        self._update_status_completed(status, job_master_id, result)
         logger.info(f"Marked job {job_id} as completed")
 
+    @deprecated_sync_method("mark_failed_async")
     def mark_failed(self, job_id: str, error_message: str) -> None:
         """Mark job creation as failed.
 
@@ -355,20 +461,14 @@ class JobCreationStateManager:
             job_id: Job ID
             error_message: Error message
         """
-        warnings.warn(
-            "mark_failed() is deprecated, use mark_failed_async() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if job_id not in self._storage:
-            logger.warning(f"Job ID {job_id} not found in state manager")
+        status = self._get_job_or_log_warning(job_id)
+        if status is None:
             return
 
-        self._storage[job_id].status = "failed"
-        self._storage[job_id].end_time = datetime.now()
-        self._storage[job_id].error_message = error_message
+        self._update_status_failed(status, error_message)
         logger.error(f"Marked job {job_id} as failed: {error_message}")
 
+    @deprecated_sync_method("get_status_async")
     def get_status(self, job_id: str) -> Optional[JobCreationStatus]:
         """Get job creation status.
 
@@ -381,12 +481,9 @@ class JobCreationStateManager:
         Returns:
             JobCreationStatus if found, None otherwise
         """
-        warnings.warn(
-            "get_status() is deprecated, use get_status_async() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self._storage.get(job_id)
+
+    # ----- Utility Methods -----
 
     def cleanup_old_jobs(self, max_age_seconds: int = 3600) -> None:
         """Remove old completed/failed jobs from storage.
@@ -397,7 +494,7 @@ class JobCreationStateManager:
             max_age_seconds: Maximum age in seconds (default: 1 hour)
         """
         current_time = datetime.now()
-        to_remove = []
+        to_remove: list[str] = []
 
         for job_id, status in self._storage.items():
             if (
@@ -406,9 +503,12 @@ class JobCreationStateManager:
             ):
                 to_remove.append(job_id)
 
+        removed_count = len(to_remove)
         for job_id in to_remove:
             del self._storage[job_id]
-            logger.info(f"Cleaned up old job {job_id}")
+
+        if removed_count > 0:
+            logger.info(f"Cleaned up {removed_count} old job(s) from L1 cache")
 
 
 # Global singleton instance

--- a/expertAgent/tests/unit/test_job_creation_state_cache.py
+++ b/expertAgent/tests/unit/test_job_creation_state_cache.py
@@ -1,0 +1,679 @@
+"""Unit tests for JobCreationStateManager Valkey integration.
+
+Tests for Issue #239: JobCreationStateManager Valkey integration.
+This test module verifies the 2-layer cache (L1: Memory, L2: Valkey) implementation
+with 90% coverage target.
+"""
+
+import warnings
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.job_creation_state import JobCreationStateManager, JobCreationStatus
+from app.services.valkey_client import ValkeyConnectionError
+
+
+@pytest.fixture
+def mock_valkey_client() -> MagicMock:
+    """Mock ValkeyClient for testing."""
+    client = MagicMock()
+    client.connect = AsyncMock()
+    client.disconnect = AsyncMock()
+    client.get = AsyncMock(return_value=None)
+    client.set = AsyncMock(return_value=True)
+    client.ping = AsyncMock(return_value=True)
+    return client
+
+
+@pytest.fixture
+def sample_job_status() -> dict[str, Any]:
+    """Sample job status data for testing."""
+    return {
+        "job_id": "test-job-123",
+        "status": "completed",
+        "progress": 100,
+        "start_time": "2025-12-05T10:00:00",
+        "end_time": "2025-12-05T10:05:00",
+        "job_master_id": "master-456",
+        "error_message": None,
+        "result": {"workflow_id": "wf-789"},
+    }
+
+
+class TestJobCreationStateManagerInit:
+    """Test JobCreationStateManager initialization with Valkey."""
+
+    @pytest.mark.unit
+    def test_init_without_valkey_client(self) -> None:
+        """Test initialization without ValkeyClient (backward compatible)."""
+        manager = JobCreationStateManager()
+        assert manager._storage == {}
+        assert manager._valkey_client is None
+
+    @pytest.mark.unit
+    def test_init_with_valkey_client(self, mock_valkey_client: MagicMock) -> None:
+        """Test initialization with ValkeyClient."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        assert manager._valkey_client is mock_valkey_client
+        assert manager._ttl_seconds == 86400  # Default 24 hours
+
+    @pytest.mark.unit
+    def test_init_with_custom_ttl(self, mock_valkey_client: MagicMock) -> None:
+        """Test initialization with custom TTL."""
+        manager = JobCreationStateManager(
+            valkey_client=mock_valkey_client, ttl_seconds=3600
+        )
+        assert manager._ttl_seconds == 3600
+
+
+class TestValkeyConnection:
+    """Test Valkey connection management."""
+
+    @pytest.mark.unit
+    async def test_connect_valkey_success(self, mock_valkey_client: MagicMock) -> None:
+        """Test successful Valkey connection."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        mock_valkey_client.connect.assert_awaited_once()
+        assert manager._valkey_connected is True
+
+    @pytest.mark.unit
+    async def test_connect_valkey_without_client(self) -> None:
+        """Test connect_valkey when no client is configured."""
+        manager = JobCreationStateManager()
+        await manager.connect_valkey()
+        # Should not raise, just skip connection
+        assert manager._valkey_connected is False
+
+    @pytest.mark.unit
+    async def test_disconnect_valkey_success(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test successful Valkey disconnection."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+        await manager.disconnect_valkey()
+
+        mock_valkey_client.disconnect.assert_awaited_once()
+        assert manager._valkey_connected is False
+
+
+class TestGetStatusAsync:
+    """Test get_status_async method with 2-layer cache."""
+
+    @pytest.mark.unit
+    async def test_get_status_async_l1_hit(self, mock_valkey_client: MagicMock) -> None:
+        """Test L1 cache hit - Valkey not accessed."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Create job in L1 cache
+        manager.create_job("test-job-123")
+
+        result = await manager.get_status_async("test-job-123")
+
+        assert result is not None
+        assert result.job_id == "test-job-123"
+        assert result.status == "creating"
+        # Valkey get should NOT be called for L1 hit
+        mock_valkey_client.get.assert_not_awaited()
+
+    @pytest.mark.unit
+    async def test_get_status_async_l1_miss_l2_hit(
+        self, mock_valkey_client: MagicMock, sample_job_status: dict[str, Any]
+    ) -> None:
+        """Test L1 miss, L2 hit - populate L1 from L2."""
+        mock_valkey_client.get = AsyncMock(return_value=sample_job_status)
+
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        result = await manager.get_status_async("test-job-123")
+
+        assert result is not None
+        assert result.job_id == "test-job-123"
+        assert result.status == "completed"
+        mock_valkey_client.get.assert_awaited_once_with("job:creation:test-job-123")
+
+        # Verify L1 cache is now populated
+        assert "test-job-123" in manager._storage
+
+    @pytest.mark.unit
+    async def test_get_status_async_not_found(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test job not found in both L1 and L2."""
+        mock_valkey_client.get = AsyncMock(return_value=None)
+
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        result = await manager.get_status_async("nonexistent-job")
+
+        assert result is None
+        mock_valkey_client.get.assert_awaited_once_with("job:creation:nonexistent-job")
+
+    @pytest.mark.unit
+    async def test_get_status_async_without_valkey(self) -> None:
+        """Test get_status_async without Valkey configured."""
+        manager = JobCreationStateManager()
+
+        # Create job in L1
+        manager.create_job("test-job-123")
+
+        result = await manager.get_status_async("test-job-123")
+
+        assert result is not None
+        assert result.job_id == "test-job-123"
+
+
+class TestMarkCompletedAsync:
+    """Test mark_completed_async method with dual write."""
+
+    @pytest.mark.unit
+    async def test_mark_completed_async_writes_to_both_layers(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test mark_completed_async writes to both L1 and L2."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Create job first
+        manager.create_job("test-job-123")
+
+        # Mark as completed
+        await manager.mark_completed_async(
+            job_id="test-job-123",
+            job_master_id="master-456",
+            result={"workflow_id": "wf-789"},
+        )
+
+        # Verify L1 cache updated
+        l1_status = manager._storage.get("test-job-123")
+        assert l1_status is not None
+        assert l1_status.status == "completed"
+        assert l1_status.progress == 100
+        assert l1_status.job_master_id == "master-456"
+
+        # Verify L2 (Valkey) was written
+        mock_valkey_client.set.assert_awaited_once()
+        call_args = mock_valkey_client.set.call_args
+        assert call_args[0][0] == "job:creation:test-job-123"
+        assert call_args.kwargs.get("ttl") == 86400
+
+    @pytest.mark.unit
+    async def test_mark_completed_async_job_not_found(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test mark_completed_async for non-existent job."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Should not raise, just log warning
+        await manager.mark_completed_async(job_id="nonexistent-job")
+
+        # Valkey should NOT be written for non-existent job
+        mock_valkey_client.set.assert_not_awaited()
+
+
+class TestMarkFailedAsync:
+    """Test mark_failed_async method."""
+
+    @pytest.mark.unit
+    async def test_mark_failed_async_writes_to_both_layers(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test mark_failed_async writes to both L1 and L2."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Create job first
+        manager.create_job("test-job-123")
+
+        # Mark as failed
+        await manager.mark_failed_async(
+            job_id="test-job-123", error_message="Something went wrong"
+        )
+
+        # Verify L1 cache updated
+        l1_status = manager._storage.get("test-job-123")
+        assert l1_status is not None
+        assert l1_status.status == "failed"
+        assert l1_status.error_message == "Something went wrong"
+
+        # Verify L2 (Valkey) was written
+        mock_valkey_client.set.assert_awaited_once()
+
+
+class TestCreateJobAsync:
+    """Test create_job_async method."""
+
+    @pytest.mark.unit
+    async def test_create_job_async_writes_to_both_layers(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test create_job_async writes to both L1 and L2."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        await manager.create_job_async("test-job-123")
+
+        # Verify L1 cache
+        l1_status = manager._storage.get("test-job-123")
+        assert l1_status is not None
+        assert l1_status.status == "creating"
+        assert l1_status.progress == 0
+
+        # Verify L2 (Valkey) was written
+        mock_valkey_client.set.assert_awaited_once()
+        call_args = mock_valkey_client.set.call_args
+        assert call_args[0][0] == "job:creation:test-job-123"
+
+
+class TestUpdateProgressAsync:
+    """Test update_progress_async method."""
+
+    @pytest.mark.unit
+    async def test_update_progress_async_writes_to_both_layers(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test update_progress_async writes to both L1 and L2."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Create job first
+        manager.create_job("test-job-123")
+
+        # Update progress
+        await manager.update_progress_async("test-job-123", 50)
+
+        # Verify L1 cache
+        l1_status = manager._storage.get("test-job-123")
+        assert l1_status is not None
+        assert l1_status.progress == 50
+
+        # Verify L2 (Valkey) was written
+        mock_valkey_client.set.assert_awaited_once()
+
+    @pytest.mark.unit
+    async def test_update_progress_async_job_not_found(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test update_progress_async for non-existent job."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Should not raise
+        await manager.update_progress_async("nonexistent-job", 50)
+
+        # Valkey should NOT be written
+        mock_valkey_client.set.assert_not_awaited()
+
+
+class TestGracefulDegradation:
+    """Test graceful degradation when Valkey is unavailable."""
+
+    @pytest.mark.unit
+    async def test_valkey_connection_failure_graceful_degradation(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test graceful degradation when Valkey connection fails."""
+        mock_valkey_client.connect = AsyncMock(
+            side_effect=ValkeyConnectionError("Connection failed")
+        )
+
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+
+        # Connection failure should not raise, should degrade gracefully
+        await manager.connect_valkey()
+        assert manager._valkey_connected is False
+
+        # Operations should still work with L1 cache only
+        manager.create_job("test-job-123")
+        result = await manager.get_status_async("test-job-123")
+
+        assert result is not None
+        assert result.job_id == "test-job-123"
+
+    @pytest.mark.unit
+    async def test_valkey_get_failure_graceful_degradation(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test graceful degradation when Valkey get fails."""
+        mock_valkey_client.get = AsyncMock(side_effect=Exception("Get failed"))
+
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Should return None without raising
+        result = await manager.get_status_async("test-job-123")
+        assert result is None
+
+    @pytest.mark.unit
+    async def test_valkey_set_failure_graceful_degradation(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test graceful degradation when Valkey set fails."""
+        mock_valkey_client.set = AsyncMock(side_effect=Exception("Set failed"))
+
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Create job first
+        manager.create_job("test-job-123")
+
+        # Should complete without raising, L1 cache still works
+        await manager.mark_completed_async(job_id="test-job-123")
+
+        # Verify L1 cache was still updated
+        l1_status = manager._storage.get("test-job-123")
+        assert l1_status is not None
+        assert l1_status.status == "completed"
+
+
+class TestDatetimeSerialization:
+    """Test datetime serialization/deserialization."""
+
+    @pytest.mark.unit
+    async def test_datetime_serialization_deserialization(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test datetime fields are properly serialized and deserialized."""
+        # Simulate Valkey returning serialized data with datetime strings
+        valkey_data = {
+            "job_id": "test-job-123",
+            "status": "completed",
+            "progress": 100,
+            "start_time": "2025-12-05T10:00:00",
+            "end_time": "2025-12-05T10:05:00",
+            "job_master_id": None,
+            "error_message": None,
+            "result": None,
+        }
+        mock_valkey_client.get = AsyncMock(return_value=valkey_data)
+
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        result = await manager.get_status_async("test-job-123")
+
+        assert result is not None
+        assert isinstance(result.start_time, datetime)
+        assert isinstance(result.end_time, datetime)
+        assert result.start_time.year == 2025
+        assert result.start_time.month == 12
+        assert result.start_time.day == 5
+
+
+class TestSyncMethodsBackwardCompatibility:
+    """Test backward compatibility of sync methods."""
+
+    @pytest.mark.unit
+    def test_sync_methods_backward_compatible(self) -> None:
+        """Test that existing sync methods still work and show deprecation warning."""
+        manager = JobCreationStateManager()
+
+        # Test create_job
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.create_job("test-job-123")
+            # Deprecation warning should be issued
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "deprecated" in str(w[0].message).lower()
+
+        # Test update_progress
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.update_progress("test-job-123", 50)
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+        # Test mark_completed
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.mark_completed("test-job-123")
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+        # Verify the operations actually worked
+        status = manager.get_status("test-job-123")
+        assert status is not None
+        assert status.status == "completed"
+
+    @pytest.mark.unit
+    def test_get_status_sync_backward_compatible(self) -> None:
+        """Test get_status sync method works with deprecation warning."""
+        manager = JobCreationStateManager()
+        manager._storage["test-job-123"] = JobCreationStatus(
+            job_id="test-job-123",
+            status="creating",
+            progress=0,
+            start_time=datetime.now(),
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = manager.get_status("test-job-123")
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+        assert result is not None
+        assert result.job_id == "test-job-123"
+
+    @pytest.mark.unit
+    def test_mark_failed_sync_backward_compatible(self) -> None:
+        """Test mark_failed sync method works with deprecation warning."""
+        manager = JobCreationStateManager()
+        manager._storage["test-job-123"] = JobCreationStatus(
+            job_id="test-job-123",
+            status="creating",
+            progress=0,
+            start_time=datetime.now(),
+        )
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.mark_failed("test-job-123", "Test error")
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+        status = manager._storage.get("test-job-123")
+        assert status is not None
+        assert status.status == "failed"
+        assert status.error_message == "Test error"
+
+    @pytest.mark.unit
+    def test_cleanup_old_jobs_backward_compatible(self) -> None:
+        """Test cleanup_old_jobs sync method works."""
+        manager = JobCreationStateManager()
+
+        # This method doesn't need deprecation warning as it's utility
+        manager.cleanup_old_jobs()
+        # Should not raise
+
+
+class TestKeyPrefix:
+    """Test Valkey key prefix configuration."""
+
+    @pytest.mark.unit
+    async def test_default_key_prefix(self, mock_valkey_client: MagicMock) -> None:
+        """Test default key prefix is job:creation:."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        manager.create_job("test-job-123")
+        await manager.mark_completed_async("test-job-123")
+
+        call_args = mock_valkey_client.set.call_args
+        assert call_args[0][0] == "job:creation:test-job-123"
+
+    @pytest.mark.unit
+    async def test_custom_key_prefix(self, mock_valkey_client: MagicMock) -> None:
+        """Test custom key prefix."""
+        manager = JobCreationStateManager(
+            valkey_client=mock_valkey_client, key_prefix="custom:prefix:"
+        )
+        await manager.connect_valkey()
+
+        manager.create_job("test-job-123")
+        await manager.mark_completed_async("test-job-123")
+
+        call_args = mock_valkey_client.set.call_args
+        assert call_args[0][0] == "custom:prefix:test-job-123"
+
+
+class TestDisconnectErrorHandling:
+    """Test disconnect error handling."""
+
+    @pytest.mark.unit
+    async def test_disconnect_valkey_error_handling(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test disconnect handles errors gracefully."""
+        mock_valkey_client.disconnect = AsyncMock(
+            side_effect=Exception("Disconnect error")
+        )
+
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Should not raise
+        await manager.disconnect_valkey()
+        assert manager._valkey_connected is False
+
+    @pytest.mark.unit
+    async def test_disconnect_valkey_when_not_connected(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test disconnect when not connected does nothing."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        # Don't connect
+
+        # Should not raise
+        await manager.disconnect_valkey()
+        mock_valkey_client.disconnect.assert_not_awaited()
+
+
+class TestSyncMethodsNotFound:
+    """Test sync methods when job is not found."""
+
+    @pytest.mark.unit
+    def test_update_progress_sync_job_not_found(self) -> None:
+        """Test update_progress sync for non-existent job."""
+        manager = JobCreationStateManager()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.update_progress("nonexistent-job", 50)
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+        # Should not raise, job not in storage
+        assert "nonexistent-job" not in manager._storage
+
+    @pytest.mark.unit
+    def test_mark_completed_sync_job_not_found(self) -> None:
+        """Test mark_completed sync for non-existent job."""
+        manager = JobCreationStateManager()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.mark_completed("nonexistent-job")
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+        # Should not raise, job not in storage
+        assert "nonexistent-job" not in manager._storage
+
+    @pytest.mark.unit
+    def test_mark_failed_sync_job_not_found(self) -> None:
+        """Test mark_failed sync for non-existent job."""
+        manager = JobCreationStateManager()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            manager.mark_failed("nonexistent-job", "Error")
+            assert len(w) >= 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+        # Should not raise, job not in storage
+        assert "nonexistent-job" not in manager._storage
+
+
+class TestCleanupOldJobs:
+    """Test cleanup_old_jobs functionality."""
+
+    @pytest.mark.unit
+    def test_cleanup_old_jobs_removes_old_completed_jobs(self) -> None:
+        """Test cleanup removes old completed jobs."""
+        from datetime import timedelta
+
+        manager = JobCreationStateManager()
+
+        # Create a job with old end_time
+        old_time = datetime.now() - timedelta(seconds=7200)  # 2 hours ago
+        manager._storage["old-job"] = JobCreationStatus(
+            job_id="old-job",
+            status="completed",
+            progress=100,
+            start_time=old_time - timedelta(seconds=60),
+            end_time=old_time,
+        )
+
+        # Create a recent job
+        manager._storage["recent-job"] = JobCreationStatus(
+            job_id="recent-job",
+            status="completed",
+            progress=100,
+            start_time=datetime.now() - timedelta(seconds=60),
+            end_time=datetime.now(),
+        )
+
+        # Cleanup with 1 hour max age
+        manager.cleanup_old_jobs(max_age_seconds=3600)
+
+        # Old job should be removed
+        assert "old-job" not in manager._storage
+        # Recent job should remain
+        assert "recent-job" in manager._storage
+
+    @pytest.mark.unit
+    def test_cleanup_old_jobs_keeps_jobs_without_end_time(self) -> None:
+        """Test cleanup keeps jobs that haven't ended."""
+        manager = JobCreationStateManager()
+
+        # Create a job without end_time (still in progress)
+        manager._storage["in-progress-job"] = JobCreationStatus(
+            job_id="in-progress-job",
+            status="creating",
+            progress=50,
+            start_time=datetime.now(),
+        )
+
+        manager.cleanup_old_jobs(max_age_seconds=0)  # Very aggressive cleanup
+
+        # Job should remain (no end_time)
+        assert "in-progress-job" in manager._storage
+
+
+class TestMarkFailedAsyncNotFound:
+    """Test mark_failed_async when job is not found."""
+
+    @pytest.mark.unit
+    async def test_mark_failed_async_job_not_found(
+        self, mock_valkey_client: MagicMock
+    ) -> None:
+        """Test mark_failed_async for non-existent job."""
+        manager = JobCreationStateManager(valkey_client=mock_valkey_client)
+        await manager.connect_valkey()
+
+        # Should not raise, just log warning
+        await manager.mark_failed_async(job_id="nonexistent-job", error_message="Error")
+
+        # Valkey should NOT be written for non-existent job
+        mock_valkey_client.set.assert_not_awaited()


### PR DESCRIPTION
## Summary

- JobCreationStateManager に 2層キャッシュ（L1: Memory, L2: Valkey）を実装
- 非同期メソッドを追加（既存の同期メソッドは後方互換性のため維持）
- Graceful Degradation: Valkey接続失敗時はL1のみで動作継続

## Changes

### 新規追加メソッド
- `connect_valkey()` / `disconnect_valkey()` - Valkey接続管理
- `get_status_async(job_id)` - L1→L2の順でキャッシュ検索
- `create_job_async(job_id)` - ジョブ作成（両層書き込み）
- `update_progress_async(job_id, progress)` - 進捗更新
- `mark_completed_async(job_id, ...)` - 完了マーク（TTL: 24h）
- `mark_failed_async(job_id, error_message)` - 失敗マーク

### キャッシュ戦略
- **Read**: Cache-Aside (L1 hit → return, L1 miss → L2 fetch → L1 populate)
- **Write**: Write-Through (L1 + L2 同時書き込み)
- **TTL**: 86400秒（24時間）

### コード品質改善
- DRY原則適用（ヘルパーメソッド抽出）
- `deprecated_sync_method` デコレータ追加
- L1/L2 cache hit/miss ログ出力

## Test Plan

- [x] 単体テスト: 34/34 passed
- [x] カバレッジ: 98.04%
- [x] 静的解析: Ruff/MyPy エラーゼロ
- [x] CI: 全ジョブ成功

## Related Issues

Resolves #239
Parent: #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)