### PR TITLE
Issue #240: marp_report_endpoints の非同期対応

### DIFF
--- a/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/acceptance-context.json
+++ b/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/acceptance-context.json
@@ -1,0 +1,61 @@
+{
+  "issue_number": 240,
+  "feature_summary": "marp_report_endpoints の非同期対応",
+  "acceptance_criteria": [
+    "GET /v1/marp-report/{job_id} が非同期で JobCreationStateManager を呼び出す",
+    "404 エラー時のメッセージが「Job not found or expired. Job results are kept for 24 hours.」に変更される",
+    "既存の正常系動作が維持される"
+  ],
+  "quality_criteria": [
+    "単体テストカバレッジ 90%以上",
+    "Ruff/MyPy エラーゼロ"
+  ],
+  "test_scenarios": [
+    {
+      "scenario_id": "AC-1",
+      "description": "非同期メソッド呼び出しの確認",
+      "type": "code_review",
+      "verification": "get_marp_report_by_job_id関数でawait job_state_manager.get_status_async(job_id)が呼び出されていること"
+    },
+    {
+      "scenario_id": "AC-2",
+      "description": "404エラーメッセージの確認",
+      "type": "code_review",
+      "verification": "404エラー時のメッセージが 'Job not found or expired. Job results are kept for 24 hours.' であること"
+    },
+    {
+      "scenario_id": "AC-3",
+      "description": "単体テストの実行",
+      "type": "test_execution",
+      "command": "cd expertAgent && uv run pytest tests/unit/test_marp_report_endpoints.py -v",
+      "expected_result": "全テストがパス"
+    },
+    {
+      "scenario_id": "AC-4",
+      "description": "カバレッジの確認",
+      "type": "coverage_check",
+      "command": "cd expertAgent && uv run pytest tests/unit/test_marp_report_endpoints.py -v --cov=app/api/v1/marp_report_endpoints --cov-report=term-missing",
+      "expected_result": "90%以上"
+    },
+    {
+      "scenario_id": "AC-5",
+      "description": "静的解析（Ruff）",
+      "type": "static_analysis",
+      "command": "cd expertAgent && uv run ruff check app/api/v1/marp_report_endpoints.py tests/unit/test_marp_report_endpoints.py",
+      "expected_result": "エラー0件"
+    },
+    {
+      "scenario_id": "AC-6",
+      "description": "型チェック（MyPy）",
+      "type": "static_analysis",
+      "command": "cd expertAgent && uv run mypy app/api/v1/marp_report_endpoints.py",
+      "expected_result": "エラー0件"
+    }
+  ],
+  "tdd_result": {
+    "status": "success",
+    "coverage": 94.31,
+    "tests_passed": 26,
+    "tests_failed": 0
+  }
+}

--- a/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/acceptance-result.json
+++ b/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/acceptance-result.json
@@ -1,0 +1,133 @@
+{
+  "status": "passed",
+  "test_cases": [
+    {
+      "scenario_id": "AC-1",
+      "scenario": "Async Method Call - get_marp_report_by_job_id uses await job_state_manager.get_status_async(job_id)",
+      "type": "code_review",
+      "result": "passed",
+      "evidence": "Line 290-291 in marp_report_endpoints.py: 'job_status = await job_state_manager.get_status_async(job_id)'"
+    },
+    {
+      "scenario_id": "AC-2",
+      "scenario": "Improved Error Message - 404 error message is 'Job not found or expired. Job results are kept for 24 hours.'",
+      "type": "code_review",
+      "result": "passed",
+      "evidence": "Line 293 in marp_report_endpoints.py: msg = \"Job not found or expired. Job results are kept for 24 hours.\""
+    },
+    {
+      "scenario_id": "AC-PRACTICAL-1",
+      "scenario": "Practical API Test - 404 Error with Improved Message via Real HTTP Request",
+      "type": "practical_api_test",
+      "command": "curl -s http://localhost:8104/v1/marp-report/nonexistent-job-id-12345",
+      "result": "passed",
+      "evidence": "HTTP 404 returned with response: {\"detail\":\"Job not found or expired. Job results are kept for 24 hours.\",\"is_json_guaranteed\":true,\"middleware_layer\":\"http_exception_handler\"}"
+    },
+    {
+      "scenario_id": "AC-PRACTICAL-2",
+      "scenario": "Practical API Test - DEBUG Log Output for 404 Case",
+      "type": "practical_api_test",
+      "result": "passed",
+      "evidence": "Server log shows: '[DEBUG] Job not found: job_id=nonexistent-job-id-12345'"
+    },
+    {
+      "scenario_id": "AC-PRACTICAL-3",
+      "scenario": "Practical API Test - Async Method Invocation via L1/L2 Cache Logs",
+      "type": "practical_api_test",
+      "result": "passed",
+      "evidence": "Server log shows async cache flow: 'L1 cache miss: job nonexistent-job-id-12345, checking L2' and 'L2 read: skipped (Valkey unavailable)'"
+    },
+    {
+      "scenario_id": "AC-3",
+      "scenario": "Unit Tests - All tests pass",
+      "type": "test_execution",
+      "command": "cd expertAgent && uv run pytest tests/unit/test_marp_report_endpoints.py -v",
+      "result": "passed",
+      "evidence": "26 passed, 0 failed in 0.04s"
+    },
+    {
+      "scenario_id": "AC-4",
+      "scenario": "Coverage Check - 90%+ coverage",
+      "type": "coverage_check",
+      "command": "cd expertAgent && uv run pytest tests/unit/test_marp_report_endpoints.py -v --cov=app.api.v1.marp_report_endpoints --cov-report=term-missing",
+      "result": "passed",
+      "evidence": "Coverage: 94.31% (123 statements, 7 missed). Missing lines: 68-75, 126, 130, 162, 342"
+    },
+    {
+      "scenario_id": "AC-5",
+      "scenario": "Static Analysis (Ruff) - 0 errors",
+      "type": "static_analysis",
+      "command": "cd expertAgent && uv run ruff check app/api/v1/marp_report_endpoints.py tests/unit/test_marp_report_endpoints.py",
+      "result": "passed",
+      "evidence": "All checks passed!"
+    },
+    {
+      "scenario_id": "AC-6",
+      "scenario": "Type Check (MyPy) - 0 errors",
+      "type": "static_analysis",
+      "command": "cd expertAgent && uv run mypy app/api/v1/marp_report_endpoints.py",
+      "result": "passed",
+      "evidence": "Success: no issues found in 1 source file"
+    }
+  ],
+  "acceptance_criteria_status": [
+    {
+      "criterion": "GET /v1/marp-report/{job_id} uses async JobCreationStateManager call",
+      "verified": true,
+      "evidence": "Code uses 'await job_state_manager.get_status_async(job_id)' at line 290"
+    },
+    {
+      "criterion": "404 error message is 'Job not found or expired. Job results are kept for 24 hours.'",
+      "verified": true,
+      "evidence": "Error message correctly set at line 293"
+    },
+    {
+      "criterion": "Existing normal operation is maintained",
+      "verified": true,
+      "evidence": "All 26 unit tests passed including success path tests"
+    }
+  ],
+  "quality_criteria_status": [
+    {
+      "criterion": "Unit test coverage 90%+",
+      "verified": true,
+      "evidence": "Coverage is 94.31%"
+    },
+    {
+      "criterion": "Ruff/MyPy errors zero",
+      "verified": true,
+      "evidence": "Ruff: All checks passed. MyPy: no issues found"
+    }
+  ],
+  "evidence_files": [
+    "expertAgent/app/api/v1/marp_report_endpoints.py",
+    "expertAgent/tests/unit/test_marp_report_endpoints.py"
+  ],
+  "summary": {
+    "total_test_cases": 9,
+    "passed": 9,
+    "failed": 0,
+    "coverage": 94.31,
+    "tests_passed": 26,
+    "tests_failed": 0,
+    "practical_api_tests": {
+      "total": 3,
+      "passed": 3,
+      "failed": 0
+    }
+  },
+  "practical_test_summary": {
+    "test_date": "2025-12-05T11:40:50+09:00",
+    "service_port": 8104,
+    "tests_performed": [
+      "HTTP 404 response with improved error message",
+      "DEBUG log output verification",
+      "Async cache flow verification (L1/L2)"
+    ],
+    "limitations": [
+      "Full E2E test with completed job requires graphAiServer and jobqueue services",
+      "Valkey unavailable in test environment - L2 cache skipped"
+    ]
+  },
+  "message": "All acceptance criteria verified successfully including 3 practical API tests. Issue #240 implementation is complete and meets all quality standards."
+}

--- a/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/progress-context.json
+++ b/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/progress-context.json
@@ -1,0 +1,96 @@
+{
+  "issue_number": 240,
+  "issue_title": "Issue #193-2: marp_report_endpoints の非同期対応",
+  "iteration": 1,
+  "phase_results": {
+    "tdd": {
+      "status": "success",
+      "coverage": 94.31,
+      "tests_total": 26,
+      "tests_passed": 26,
+      "tests_failed": 0,
+      "static_analysis": {
+        "ruff_errors": 0,
+        "mypy_errors": 0
+      },
+      "files_changed": [
+        "expertAgent/app/api/v1/marp_report_endpoints.py",
+        "expertAgent/tests/unit/test_marp_report_endpoints.py"
+      ],
+      "tests_added": [
+        "test_get_marp_report_by_job_id_success",
+        "test_get_marp_report_by_job_id_not_found",
+        "test_get_marp_report_by_job_id_not_completed",
+        "test_get_marp_report_by_job_id_no_result",
+        "test_get_marp_report_by_job_id_template_error"
+      ],
+      "commits": [
+        "4306051: fix(expertAgent): async migration for get_marp_report_by_job_id endpoint"
+      ]
+    },
+    "acceptance": {
+      "status": "passed",
+      "test_cases": [
+        {"scenario_id": "AC-1", "description": "Async Method Call", "result": "passed"},
+        {"scenario_id": "AC-2", "description": "Improved Error Message", "result": "passed"},
+        {"scenario_id": "AC-3", "description": "Unit Tests", "result": "passed"},
+        {"scenario_id": "AC-4", "description": "Coverage Check", "result": "passed"},
+        {"scenario_id": "AC-5", "description": "Ruff Static Analysis", "result": "passed"},
+        {"scenario_id": "AC-6", "description": "MyPy Type Check", "result": "passed"}
+      ],
+      "acceptance_criteria_verified": {
+        "async_call": true,
+        "improved_error_message": true,
+        "existing_behavior_maintained": true,
+        "coverage_90_percent": true,
+        "ruff_mypy_zero_errors": true
+      }
+    },
+    "refactor": {
+      "status": "success",
+      "refactorings_applied": [],
+      "message": "No refactoring required. Code already meets all quality standards.",
+      "solid_compliance": {
+        "single_responsibility": "Pass",
+        "open_closed": "Pass",
+        "dependency_inversion": "Pass"
+      }
+    }
+  },
+  "work_plan_comparison": {
+    "has_work_plan": true,
+    "planned_tasks": [
+      {"task_id": "1.1", "description": "非同期メソッド呼び出しへの変更", "estimated_minutes": 15, "status": "completed"},
+      {"task_id": "1.2", "description": "エラーメッセージの改善", "estimated_minutes": 10, "status": "completed"},
+      {"task_id": "1.3", "description": "import文の確認", "estimated_minutes": 5, "status": "completed"},
+      {"task_id": "1.4", "description": "ログメッセージの追加", "estimated_minutes": 15, "status": "completed"},
+      {"task_id": "2.1", "description": "既存テストの確認・修正", "estimated_minutes": 15, "status": "completed"},
+      {"task_id": "2.2", "description": "正常系テスト作成", "estimated_minutes": 15, "status": "completed"},
+      {"task_id": "2.3", "description": "404テスト作成", "estimated_minutes": 15, "status": "completed"},
+      {"task_id": "2.4", "description": "400テスト作成", "estimated_minutes": 15, "status": "completed"},
+      {"task_id": "3.1", "description": "Ruff チェック・修正", "estimated_minutes": 10, "status": "completed"},
+      {"task_id": "3.2", "description": "MyPy 型チェック・修正", "estimated_minutes": 10, "status": "completed"},
+      {"task_id": "3.3", "description": "テストカバレッジ確認", "estimated_minutes": 10, "status": "completed"}
+    ],
+    "deliverables_status": [
+      {"file": "expertAgent/app/api/v1/marp_report_endpoints.py", "created": true, "changes": "async call, error message, debug log"},
+      {"file": "expertAgent/tests/unit/test_marp_report_endpoints.py", "created": true, "changes": "5 test cases added"}
+    ],
+    "definition_of_done_status": [
+      {"criterion": "GET /v1/marp-report/{job_id} が非同期で JobCreationStateManager を呼び出す", "verified": true},
+      {"criterion": "404 エラー時のメッセージが改善版に変更される", "verified": true},
+      {"criterion": "既存の正常系動作が維持される", "verified": true},
+      {"criterion": "単体テストカバレッジ 90%以上", "verified": true},
+      {"criterion": "Ruff/MyPy エラーゼロ", "verified": true}
+    ],
+    "estimated_vs_actual": {
+      "estimated_minutes": 135,
+      "notes": "自動化により効率的に完了"
+    }
+  },
+  "blockers": [],
+  "next_steps": [
+    "PRレビュー依頼",
+    "mainブランチへのマージ"
+  ]
+}

--- a/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/progress-report.md
+++ b/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/progress-report.md
@@ -1,0 +1,208 @@
+# Progress Report - Issue #240 (Iteration 1)
+
+## Overview
+
+**Issue**: #240 - marp_report_endpoints の非同期対応
+**Parent Issue**: #193 (Marp Report Persistence)
+**Iteration**: 1
+**Report Date**: 2025-12-05
+**Status**: SUCCESS - All phases completed successfully
+
+---
+
+## Phase Results
+
+### Phase 1: TDD Implementation
+
+**Status**: SUCCESS
+
+| Metric | Target | Actual | Status |
+|--------|--------|--------|--------|
+| Coverage | 90%+ | 94.31% | PASS |
+| Tests Passed | - | 26/26 | PASS |
+| Tests Failed | 0 | 0 | PASS |
+| Ruff Errors | 0 | 0 | PASS |
+| MyPy Errors | 0 | 0 | PASS |
+
+**Changed Files**:
+- `expertAgent/app/api/v1/marp_report_endpoints.py`
+- `expertAgent/tests/unit/test_marp_report_endpoints.py`
+
+**Implementation Details**:
+| File | Line | Change |
+|------|------|--------|
+| marp_report_endpoints.py | 290 | Changed `job_state_manager.get_status(job_id)` to `await job_state_manager.get_status_async(job_id)` |
+| marp_report_endpoints.py | 293-295 | Improved 404 error message to "Job not found or expired. Job results are kept for 24 hours." and added DEBUG log |
+
+**Tests Added** (5 new test cases):
+1. `test_get_marp_report_by_job_id_success`
+2. `test_get_marp_report_by_job_id_not_found`
+3. `test_get_marp_report_by_job_id_not_completed`
+4. `test_get_marp_report_by_job_id_no_result`
+5. `test_get_marp_report_by_job_id_template_error`
+
+**Commits**:
+- `4306051`: fix(expertAgent): async migration for get_marp_report_by_job_id endpoint
+
+---
+
+### Phase 2: Acceptance Testing
+
+**Status**: PASSED
+
+#### Code Review & Automated Tests
+
+| Test Case | Scenario | Type | Result |
+|-----------|----------|------|--------|
+| AC-1 | Async Method Call | Code Review | PASSED |
+| AC-2 | Improved Error Message | Code Review | PASSED |
+| AC-3 | Unit Tests | Test Execution | PASSED |
+| AC-4 | Coverage Check (90%+) | Coverage Check | PASSED |
+| AC-5 | Ruff Static Analysis | Static Analysis | PASSED |
+| AC-6 | MyPy Type Check | Static Analysis | PASSED |
+
+#### Practical API Tests (Real HTTP Requests)
+
+| Test Case | Scenario | Type | Result |
+|-----------|----------|------|--------|
+| AC-PRACTICAL-1 | 404 Error with Improved Message | Real API Call | PASSED |
+| AC-PRACTICAL-2 | DEBUG Log Output | Log Verification | PASSED |
+| AC-PRACTICAL-3 | Async Cache Flow (L1/L2) | Log Verification | PASSED |
+
+**Practical Test Evidence**:
+```bash
+# Request
+curl -s http://localhost:8104/v1/marp-report/nonexistent-job-id-12345
+
+# Response (HTTP 404)
+{"detail":"Job not found or expired. Job results are kept for 24 hours.","is_json_guaranteed":true}
+
+# Server Logs
+[DEBUG] L1 cache miss: job nonexistent-job-id-12345, checking L2
+[DEBUG] L2 read: skipped for job nonexistent-job-id-12345 (Valkey unavailable)
+[DEBUG] Job not found: job_id=nonexistent-job-id-12345
+```
+
+**Evidence**:
+- AC-1: Line 290-291 uses `await job_state_manager.get_status_async(job_id)`
+- AC-2: Line 293 sets error message to "Job not found or expired. Job results are kept for 24 hours."
+- AC-3: 26 passed, 0 failed in 0.04s
+- AC-4: Coverage is 94.31% (123 statements, 7 missed)
+- AC-5: Ruff - All checks passed
+- AC-6: MyPy - Success: no issues found in 1 source file
+
+**Practical Test Limitations**:
+- Full E2E test with completed job requires graphAiServer and jobqueue services
+- Valkey unavailable in test environment - L2 cache skipped
+
+---
+
+### Phase 3: Refactoring
+
+**Status**: SUCCESS (No Changes Required)
+
+**Quality Metrics**:
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| Coverage | 94.31% | 94.31% | 0% (Already excellent) |
+| Ruff Errors | 0 | 0 | No change |
+| MyPy Errors | 0 | 0 | No change |
+
+**SOLID Compliance**:
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| Single Responsibility | PASS | Functions are well-decomposed with clear responsibilities |
+| Open/Closed | PASS | Template system allows extension without modification |
+| Liskov Substitution | N/A | No class inheritance in this module |
+| Interface Segregation | N/A | No interfaces defined in this module |
+| Dependency Inversion | PASS | Uses job_state_manager as injected dependency |
+
+**Recommendation**: No changes required. The async migration for Issue #240 was minimal and the code quality is excellent.
+
+---
+
+## Work Plan Comparison
+
+### Planned vs Actual
+
+| Phase | Task ID | Description | Est. (min) | Status |
+|-------|---------|-------------|------------|--------|
+| Implementation | 1.1 | Async method call change | 15 | COMPLETED |
+| Implementation | 1.2 | Error message improvement | 10 | COMPLETED |
+| Implementation | 1.3 | Import statement check | 5 | COMPLETED |
+| Implementation | 1.4 | Log message addition | 15 | COMPLETED |
+| Testing | 2.1 | Existing test verification | 15 | COMPLETED |
+| Testing | 2.2 | Success case tests | 15 | COMPLETED |
+| Testing | 2.3 | 404 case tests | 15 | COMPLETED |
+| Testing | 2.4 | 400 case tests | 15 | COMPLETED |
+| Quality | 3.1 | Ruff check/fix | 10 | COMPLETED |
+| Quality | 3.2 | MyPy type check/fix | 10 | COMPLETED |
+| Quality | 3.3 | Coverage verification | 10 | COMPLETED |
+
+**Total Estimated**: 135 minutes
+**Result**: All 11 tasks completed efficiently via automation
+
+### Deliverables Status
+
+| File | Created | Changes |
+|------|---------|---------|
+| `expertAgent/app/api/v1/marp_report_endpoints.py` | Yes | async call, error message, debug log |
+| `expertAgent/tests/unit/test_marp_report_endpoints.py` | Yes | 5 test cases added |
+
+---
+
+## Definition of Done Verification
+
+| Criterion | Verified | Evidence |
+|-----------|----------|----------|
+| GET /v1/marp-report/{job_id} uses async JobCreationStateManager call | YES | Code uses `await job_state_manager.get_status_async(job_id)` at line 290 |
+| 404 error message is "Job not found or expired. Job results are kept for 24 hours." | YES | Error message correctly set at line 293 |
+| Existing normal operation is maintained | YES | All 26 unit tests passed including success path tests |
+| Unit test coverage 90%+ | YES | Coverage is 94.31% |
+| Ruff/MyPy errors zero | YES | Ruff: All checks passed. MyPy: no issues found |
+
+---
+
+## Quality Metrics Summary
+
+| Metric | Target | Actual | Status |
+|--------|--------|--------|--------|
+| Unit Test Coverage | 90%+ | 94.31% | PASS |
+| Unit Tests Passed | All | 26/26 | PASS |
+| Static Analysis (Ruff) | 0 errors | 0 errors | PASS |
+| Type Check (MyPy) | 0 errors | 0 errors | PASS |
+| Acceptance Criteria | All verified | 3/3 verified | PASS |
+| Quality Criteria | All verified | 2/2 verified | PASS |
+
+---
+
+## Blockers
+
+None. All phases completed successfully without any blockers.
+
+---
+
+## Next Steps
+
+1. **PR Review Request** - Submit implementation for code review
+2. **Merge to main branch** - After approval, merge changes to main
+
+---
+
+## Git History
+
+| Commit | Message |
+|--------|---------|
+| `4306051` | fix(expertAgent): async migration for get_marp_report_by_job_id endpoint |
+| `1492182` | docs(issue/240): add work plan for marp_report_endpoints async migration |
+
+---
+
+## Notes
+
+- All phases completed successfully
+- Quality standards exceeded (94.31% coverage vs 90% target)
+- Code already follows SOLID principles - no refactoring needed
+- Implementation was minimal and focused - only changed what was necessary
+
+**Issue #240 implementation is complete and ready for PR review.**

--- a/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/refactor-context.json
+++ b/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/refactor-context.json
@@ -1,0 +1,22 @@
+{
+  "issue_number": 240,
+  "refactor_targets": [
+    "expertAgent/app/api/v1/marp_report_endpoints.py"
+  ],
+  "quality_metrics": {
+    "before_coverage": 94.31,
+    "complexity_score": null
+  },
+  "design_patterns_to_apply": [],
+  "improvement_goals": [
+    "コードの簡潔性を維持",
+    "不要な重複を削除（該当があれば）",
+    "SOLID原則への準拠確認"
+  ],
+  "constraints": [
+    "既存テストが引き続きパスすること",
+    "カバレッジが90%以上を維持すること",
+    "静的解析エラーが0件であること"
+  ],
+  "notes": "変更は軽微（非同期呼び出しとエラーメッセージ改善のみ）のため、大規模なリファクタリングは不要。コード品質の確認が主目的。"
+}

--- a/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/refactor-result.json
+++ b/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/refactor-result.json
@@ -1,0 +1,33 @@
+{
+  "status": "success",
+  "quality_metrics": {
+    "before_coverage": 94.31,
+    "after_coverage": 94.31,
+    "before_complexity": null,
+    "after_complexity": null
+  },
+  "refactorings_applied": [],
+  "files_changed": [],
+  "static_analysis": {
+    "ruff_errors_before": 0,
+    "ruff_errors_after": 0,
+    "mypy_errors_before": 0,
+    "mypy_errors_after": 0
+  },
+  "commits": [],
+  "message": "No refactoring required. Code already meets all quality standards: 26/26 tests pass, coverage 94.31% (exceeds 90% requirement), 0 static analysis errors (Ruff/MyPy). The code follows SOLID principles with well-decomposed functions (_load_job_result, _extract_template_data, _count_slides, etc.). Minor template rendering duplication exists between POST and GET endpoints but the overhead of extraction outweighs the benefit given the different parameter handling and response types.",
+  "analysis_details": {
+    "solid_compliance": {
+      "single_responsibility": "Pass - Functions are well-decomposed with clear responsibilities",
+      "open_closed": "Pass - Template system allows extension without modification",
+      "liskov_substitution": "N/A - No class inheritance in this module",
+      "interface_segregation": "N/A - No interfaces defined in this module",
+      "dependency_inversion": "Pass - Uses job_state_manager as injected dependency"
+    },
+    "code_smells_detected": [],
+    "tests_passed": 26,
+    "tests_total": 26,
+    "uncovered_lines": [68, 69, 70, 71, 72, 73, 74, 75, 126, 130, 162, 342],
+    "recommendation": "No changes required. The async migration for Issue #240 was minimal and the code quality is excellent."
+  }
+}

--- a/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/tdd-context.json
+++ b/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/tdd-context.json
@@ -1,0 +1,103 @@
+{
+  "issue_number": 240,
+  "title": "Issue #193-2: marp_report_endpoints の非同期対応",
+  "acceptance_criteria": [
+    "GET /v1/marp-report/{job_id} が非同期で JobCreationStateManager を呼び出す",
+    "404 エラー時のメッセージが「Job not found or expired. Job results are kept for 24 hours.」に変更される",
+    "既存の正常系動作が維持される"
+  ],
+  "quality_criteria": [
+    "単体テストカバレッジ 90%以上",
+    "Ruff/MyPy エラーゼロ"
+  ],
+  "test_cases": [
+    "正常系: 完了済みジョブのスライド取得成功",
+    "異常系: 存在しない job_id で 404 + 改善メッセージ",
+    "異常系: 未完了ジョブで 400 エラー"
+  ],
+  "implementation_tasks": [
+    {
+      "task_id": "1.1",
+      "description": "非同期メソッド呼び出しへの変更",
+      "file": "expertAgent/app/api/v1/marp_report_endpoints.py",
+      "line": 290,
+      "change": "job_state_manager.get_status(job_id) → await job_state_manager.get_status_async(job_id)"
+    },
+    {
+      "task_id": "1.2",
+      "description": "エラーメッセージの改善",
+      "file": "expertAgent/app/api/v1/marp_report_endpoints.py",
+      "lines": "293-294",
+      "change": "msg = f\"Job ID not found: {job_id}\" → msg = \"Job not found or expired. Job results are kept for 24 hours.\""
+    },
+    {
+      "task_id": "1.3",
+      "description": "DEBUGログ追加（オプション）",
+      "file": "expertAgent/app/api/v1/marp_report_endpoints.py",
+      "change": "404エラー時にlogger.debug出力を追加"
+    },
+    {
+      "task_id": "2.1",
+      "description": "正常系テスト作成",
+      "file": "expertAgent/tests/unit/test_marp_report_endpoints.py",
+      "test_name": "test_get_marp_report_by_job_id_success"
+    },
+    {
+      "task_id": "2.2",
+      "description": "404テスト作成",
+      "file": "expertAgent/tests/unit/test_marp_report_endpoints.py",
+      "test_name": "test_get_marp_report_by_job_id_not_found"
+    },
+    {
+      "task_id": "2.3",
+      "description": "400テスト作成",
+      "file": "expertAgent/tests/unit/test_marp_report_endpoints.py",
+      "test_name": "test_get_marp_report_by_job_id_not_completed"
+    }
+  ],
+  "work_plan_tasks": [
+    {
+      "task_id": "1.1",
+      "description": "非同期メソッド呼び出しへの変更",
+      "estimated_minutes": 15,
+      "deliverables": ["expertAgent/app/api/v1/marp_report_endpoints.py"]
+    },
+    {
+      "task_id": "1.2",
+      "description": "エラーメッセージの改善",
+      "estimated_minutes": 10,
+      "deliverables": ["expertAgent/app/api/v1/marp_report_endpoints.py"]
+    },
+    {
+      "task_id": "2.1-2.4",
+      "description": "テスト作成・更新",
+      "estimated_minutes": 60,
+      "deliverables": ["expertAgent/tests/unit/test_marp_report_endpoints.py"]
+    },
+    {
+      "task_id": "3.1-3.3",
+      "description": "品質保証（Ruff, MyPy, カバレッジ）",
+      "estimated_minutes": 30,
+      "deliverables": ["リントエラーゼロ", "型エラーゼロ", "カバレッジ90%以上"]
+    }
+  ],
+  "deliverables_checklist": [
+    "expertAgent/app/api/v1/marp_report_endpoints.py (Line 290: get_status_async, Lines 293-294: 改善メッセージ)",
+    "expertAgent/tests/unit/test_marp_report_endpoints.py (3テストケース追加)"
+  ],
+  "definition_of_done": [
+    "GET /v1/marp-report/{job_id} が非同期で JobCreationStateManager を呼び出す",
+    "404 エラー時のメッセージが改善版に変更される",
+    "既存の正常系動作が維持される",
+    "単体テストカバレッジ 90%以上",
+    "Ruff/MyPy エラーゼロ"
+  ],
+  "target_coverage": 90,
+  "current_code_snapshot": {
+    "file": "expertAgent/app/api/v1/marp_report_endpoints.py",
+    "target_function": "get_marp_report_by_job_id",
+    "lines_to_change": [290, 293, 294],
+    "current_line_290": "job_status = job_state_manager.get_status(job_id)",
+    "current_line_293_294": "msg = f\"Job ID not found: {job_id}\"\nraise HTTPException(status_code=404, detail=msg)"
+  }
+}

--- a/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/tdd-result.json
+++ b/dev-reports/feature/issue/240/pm-auto-dev/iteration-1/tdd-result.json
@@ -1,0 +1,49 @@
+{
+  "status": "success",
+  "coverage": 94.31,
+  "unit_tests": {
+    "total": 26,
+    "passed": 26,
+    "failed": 0
+  },
+  "static_analysis": {
+    "ruff_errors": 0,
+    "mypy_errors": 0
+  },
+  "files_changed": [
+    "expertAgent/app/api/v1/marp_report_endpoints.py",
+    "expertAgent/tests/unit/test_marp_report_endpoints.py"
+  ],
+  "commits": [
+    "4306051: fix(expertAgent): async migration for get_marp_report_by_job_id endpoint"
+  ],
+  "implementation_summary": {
+    "changes_made": [
+      {
+        "file": "expertAgent/app/api/v1/marp_report_endpoints.py",
+        "line": 290,
+        "change": "Changed job_state_manager.get_status(job_id) to await job_state_manager.get_status_async(job_id)"
+      },
+      {
+        "file": "expertAgent/app/api/v1/marp_report_endpoints.py",
+        "lines": "293-295",
+        "change": "Improved 404 error message to 'Job not found or expired. Job results are kept for 24 hours.' and added DEBUG log"
+      }
+    ],
+    "tests_added": [
+      "test_get_marp_report_by_job_id_success",
+      "test_get_marp_report_by_job_id_not_found",
+      "test_get_marp_report_by_job_id_not_completed",
+      "test_get_marp_report_by_job_id_no_result",
+      "test_get_marp_report_by_job_id_template_error"
+    ]
+  },
+  "acceptance_criteria_verified": {
+    "async_call": true,
+    "improved_error_message": true,
+    "existing_behavior_maintained": true,
+    "coverage_90_percent": true,
+    "ruff_mypy_zero_errors": true
+  },
+  "message": "TDD implementation completed successfully. Coverage 94.31% exceeds 90% target. All 5 test cases for get_marp_report_by_job_id added."
+}

--- a/dev-reports/feature/issue/240/work-plan.md
+++ b/dev-reports/feature/issue/240/work-plan.md
@@ -1,0 +1,339 @@
+# Issue #240 作業計画書
+
+## marp_report_endpoints の非同期対応
+
+---
+
+## Issue 概要
+
+| 項目 | 値 |
+|-----|-----|
+| **Issue番号** | [#240](https://github.com/Kewton/MySwiftAgent/issues/240) |
+| **親Issue** | [#193](https://github.com/Kewton/MySwiftAgent/issues/193) |
+| **サイズ** | S (2 Story Points) |
+| **作業見積** | 2-3時間 |
+| **優先度** | High |
+| **Phase** | 2（エンドポイント更新） |
+| **依存Issue** | #239（JobCreationStateManager の非同期メソッドが必要） |
+| **並列可能** | #241 と並列実行可能 |
+
+---
+
+## 現状分析
+
+### 変更対象コード
+
+**`expertAgent/app/api/v1/marp_report_endpoints.py` (Lines 289-294)**:
+```python
+# 現在の実装
+job_status = job_state_manager.get_status(job_id)
+
+if not job_status:
+    msg = f"Job ID not found: {job_id}"
+    raise HTTPException(status_code=404, detail=msg)
+```
+
+### 変更後のコード
+
+```python
+# 非同期対応後
+job_status = await job_state_manager.get_status_async(job_id)
+
+if not job_status:
+    msg = "Job not found or expired. Job results are kept for 24 hours."
+    raise HTTPException(status_code=404, detail=msg)
+```
+
+---
+
+## 詳細タスク分解
+
+### Phase 1: 実装（45分）
+
+#### Task 1.1: 非同期メソッド呼び出しへの変更
+- **所要時間**: 15分
+- **成果物**: `expertAgent/app/api/v1/marp_report_endpoints.py`
+- **依存**: なし
+- **内容**:
+  - Line 290: `job_state_manager.get_status(job_id)` → `await job_state_manager.get_status_async(job_id)`
+  - 関数は既に `async def` なので追加変更不要
+
+#### Task 1.2: エラーメッセージの改善
+- **所要時間**: 10分
+- **成果物**: `expertAgent/app/api/v1/marp_report_endpoints.py`
+- **依存**: Task 1.1
+- **内容**:
+  - Line 293-294: エラーメッセージを改善
+  - 現在: `f"Job ID not found: {job_id}"`
+  - 改善後: `"Job not found or expired. Job results are kept for 24 hours."`
+
+#### Task 1.3: import 文の確認
+- **所要時間**: 5分
+- **成果物**: `expertAgent/app/api/v1/marp_report_endpoints.py`
+- **依存**: Task 1.1
+- **内容**:
+  - `job_state_manager` のインポートが正しいことを確認
+  - 非同期メソッドが利用可能であることを確認（#239 完了が前提）
+
+#### Task 1.4: ログメッセージの追加（オプション）
+- **所要時間**: 15分
+- **成果物**: `expertAgent/app/api/v1/marp_report_endpoints.py`
+- **依存**: Task 1.2
+- **内容**:
+  - 404 エラー時に DEBUG レベルでログ出力
+  - `logger.debug(f"Job not found or expired: job_id={job_id}")`
+
+### Phase 2: テスト更新（1時間）
+
+#### Task 2.1: 既存テストの確認・修正
+- **所要時間**: 15分
+- **成果物**: `expertAgent/tests/unit/test_marp_report_endpoints.py`
+- **依存**: Phase 1 完了
+- **内容**:
+  - `get_marp_report_by_job_id` 関数のテストが既存か確認
+  - 既存テストがあれば非同期モック対応に修正
+
+#### Task 2.2: 正常系テスト作成
+- **所要時間**: 15分
+- **成果物**: `test_get_marp_report_by_job_id_success`
+- **依存**: Task 2.1
+- **内容**:
+  - 完了済みジョブのスライド取得成功
+  - `job_state_manager.get_status_async` をモック
+  - レスポンス構造の検証
+
+#### Task 2.3: 異常系テスト - job_id 不存在
+- **所要時間**: 15分
+- **成果物**: `test_get_marp_report_by_job_id_not_found`
+- **依存**: Task 2.1
+- **内容**:
+  - 存在しない job_id で 404 エラー
+  - **重要**: エラーメッセージが改善版であることを検証
+  - `"Job not found or expired"` が含まれることを確認
+
+#### Task 2.4: 異常系テスト - 未完了ジョブ
+- **所要時間**: 15分
+- **成果物**: `test_get_marp_report_by_job_id_not_completed`
+- **依存**: Task 2.1
+- **内容**:
+  - 未完了（`status="creating"`）ジョブで 400 エラー
+  - エラーメッセージに現在のステータスが含まれることを検証
+
+### Phase 3: 品質保証（30分）
+
+#### Task 3.1: Ruff チェック・修正
+- **所要時間**: 10分
+- **成果物**: リントエラーゼロ
+- **依存**: Phase 1, 2 完了
+- **コマンド**: `uv run ruff check expertAgent/app/api/v1/marp_report_endpoints.py expertAgent/tests/unit/test_marp_report_endpoints.py`
+
+#### Task 3.2: MyPy 型チェック・修正
+- **所要時間**: 10分
+- **成果物**: 型エラーゼロ
+- **依存**: Task 3.1
+- **コマンド**: `uv run mypy expertAgent/app/api/v1/marp_report_endpoints.py`
+
+#### Task 3.3: テストカバレッジ確認
+- **所要時間**: 10分
+- **成果物**: 90%以上のカバレッジ
+- **依存**: Task 3.2
+- **コマンド**: `uv run pytest expertAgent/tests/unit/test_marp_report_endpoints.py -v --cov=expertAgent/app/api/v1/marp_report_endpoints --cov-report=term-missing`
+
+---
+
+## タスク依存関係
+
+```mermaid
+graph TD
+    subgraph "Phase 1: 実装"
+        T11[Task 1.1<br/>非同期呼び出し変更]
+        T12[Task 1.2<br/>エラーメッセージ改善]
+        T13[Task 1.3<br/>import確認]
+        T14[Task 1.4<br/>ログ追加]
+    end
+
+    subgraph "Phase 2: テスト"
+        T21[Task 2.1<br/>既存テスト確認]
+        T22[Task 2.2<br/>正常系テスト]
+        T23[Task 2.3<br/>404テスト]
+        T24[Task 2.4<br/>400テスト]
+    end
+
+    subgraph "Phase 3: 品質保証"
+        T31[Task 3.1<br/>Ruff チェック]
+        T32[Task 3.2<br/>MyPy チェック]
+        T33[Task 3.3<br/>カバレッジ確認]
+    end
+
+    T11 --> T12
+    T11 --> T13
+    T12 --> T14
+
+    T14 --> T21
+    T21 --> T22
+    T21 --> T23
+    T21 --> T24
+
+    T22 --> T31
+    T23 --> T31
+    T24 --> T31
+    T31 --> T32
+    T32 --> T33
+```
+
+---
+
+## 作業スケジュール
+
+### Session 1 (2-3時間)
+
+| 時間 | タスク | 成果物 |
+|------|--------|--------|
+| 0:00-0:15 | Task 1.1 | 非同期呼び出し変更完了 |
+| 0:15-0:25 | Task 1.2 | エラーメッセージ改善完了 |
+| 0:25-0:30 | Task 1.3 | import 確認完了 |
+| 0:30-0:45 | Task 1.4 | ログ追加（オプション） |
+| 0:45-1:00 | Task 2.1 | 既存テスト確認・修正 |
+| 1:00-1:15 | Task 2.2 | 正常系テスト作成 |
+| 1:15-1:30 | Task 2.3 | 404 テスト作成 |
+| 1:30-1:45 | Task 2.4 | 400 テスト作成 |
+| 1:45-1:55 | Task 3.1 | Ruff チェック |
+| 1:55-2:05 | Task 3.2 | MyPy チェック |
+| 2:05-2:15 | Task 3.3 | カバレッジ確認 |
+
+**総作業時間**: 約2-2.5時間
+
+---
+
+## チェックポイント
+
+| タイミング | 確認事項 | 対応 |
+|-----------|---------|------|
+| Task 1.2 完了時 | 手動で 404 エラーメッセージ確認 | curl またはテストで確認 |
+| Phase 1 完了時 | 既存テストがパスすること | `uv run pytest` で確認 |
+| Task 2.3 完了時 | 改善メッセージがテストで検証されること | テストコード確認 |
+| Phase 3 完了時 | CI 品質基準達成 | カバレッジ・静的解析確認 |
+
+---
+
+## リスクと対策
+
+| リスク | 発生確率 | 影響 | 対策 |
+|-------|---------|------|------|
+| #239 未完了 | 低 | 作業ブロック | #239 の完了を待つ |
+| 非同期モックの複雑さ | 中 | テスト遅延30分 | `AsyncMock` 使用 |
+| 既存テスト破損 | 低 | 修正30分 | 変更箇所のみテスト対象 |
+
+---
+
+## 成果物チェックリスト
+
+### コード
+- [ ] `expertAgent/app/api/v1/marp_report_endpoints.py`
+  - [ ] Line 290: `get_status_async()` 呼び出し
+  - [ ] Line 293-294: 改善エラーメッセージ
+  - [ ] DEBUG ログ追加（オプション）
+
+### テスト
+- [ ] `expertAgent/tests/unit/test_marp_report_endpoints.py`
+  - [ ] `test_get_marp_report_by_job_id_success`
+  - [ ] `test_get_marp_report_by_job_id_not_found`
+  - [ ] `test_get_marp_report_by_job_id_not_completed`
+
+### 品質
+- [ ] Ruff チェックパス
+- [ ] MyPy 型チェックパス
+- [ ] 単体テストカバレッジ 90%以上
+
+---
+
+## Definition of Done
+
+Issue #240 完了条件：
+
+### 🤖 自動検証可能な基準（必須）
+- [ ] 全タスク完了
+- [ ] `GET /v1/marp-report/{job_id}` が非同期で `JobCreationStateManager` を呼び出す
+- [ ] 404 エラー時のメッセージが「Job not found or expired...」に変更される
+- [ ] 既存の正常系動作が維持される
+- [ ] 単体テストカバレッジ 90%以上
+- [ ] Ruff/MyPy エラーゼロ
+
+### 👤 手動検証が必要な基準（推奨）
+- [ ] フロントエンドでエラーメッセージが正しく表示される
+
+---
+
+## テストコード参考
+
+### 非同期モックの使用例
+
+```python
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from datetime import datetime
+
+from app.api.v1.marp_report_endpoints import get_marp_report_by_job_id
+from app.services.job_creation_state import JobCreationStatus
+
+
+class TestGetMarpReportByJobId:
+    """Test get_marp_report_by_job_id endpoint."""
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.marp_report_endpoints.job_state_manager")
+    async def test_get_marp_report_by_job_id_not_found(
+        self, mock_manager: MagicMock
+    ):
+        """Test 404 error with improved message."""
+        # Mock get_status_async to return None
+        mock_manager.get_status_async = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_marp_report_by_job_id("nonexistent-job-id")
+
+        assert exc_info.value.status_code == 404
+        assert "Job not found or expired" in str(exc_info.value.detail)
+        assert "24 hours" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.marp_report_endpoints.job_state_manager")
+    async def test_get_marp_report_by_job_id_not_completed(
+        self, mock_manager: MagicMock
+    ):
+        """Test 400 error for incomplete job."""
+        # Mock job status with creating status
+        mock_status = JobCreationStatus(
+            job_id="test-job-id",
+            status="creating",
+            progress=50,
+            start_time=datetime.now(),
+        )
+        mock_manager.get_status_async = AsyncMock(return_value=mock_status)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_marp_report_by_job_id("test-job-id")
+
+        assert exc_info.value.status_code == 400
+        assert "not completed" in str(exc_info.value.detail).lower()
+```
+
+---
+
+## 次のアクション
+
+作業計画承認後：
+1. **前提確認**: Issue #239 が完了していることを確認
+2. **ブランチ作成**: `fix/issue/240` または既存の `fix/issue/239` ブランチで作業
+3. **TDD 開発開始**: `/pm-auto-dev 240` または `/tdd-impl 240`
+4. **進捗報告**: `/progress-report 240` で報告
+
+---
+
+## 関連ドキュメント
+
+- [Issue #240](https://github.com/Kewton/MySwiftAgent/issues/240)
+- [Issue #193 (親Issue)](https://github.com/Kewton/MySwiftAgent/issues/193)
+- [Issue #239 (依存先)](https://github.com/Kewton/MySwiftAgent/issues/239)
+- [requirements.md](../issue/193/requirements.md)
+- [design-policy.md](../issue/193/design-policy.md)

--- a/expertAgent/app/api/v1/marp_report_endpoints.py
+++ b/expertAgent/app/api/v1/marp_report_endpoints.py
@@ -286,11 +286,12 @@ async def get_marp_report_by_job_id(
     """
     start_time = time.time()
 
-    # Get job status from state manager
-    job_status = job_state_manager.get_status(job_id)
+    # Get job status from state manager (async for 2-layer cache support)
+    job_status = await job_state_manager.get_status_async(job_id)
 
     if not job_status:
-        msg = f"Job ID not found: {job_id}"
+        msg = "Job not found or expired. Job results are kept for 24 hours."
+        logger.debug(f"Job not found: job_id={job_id}")
         raise HTTPException(status_code=404, detail=msg)
 
     if job_status.status != "completed":

--- a/expertAgent/tests/unit/test_marp_report_endpoints.py
+++ b/expertAgent/tests/unit/test_marp_report_endpoints.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -13,8 +13,10 @@ from app.api.v1.marp_report_endpoints import (
     _extract_template_data,
     _load_job_result,
     generate_marp_report,
+    get_marp_report_by_job_id,
 )
 from app.schemas.marp_report import MarpReportRequest, MarpReportResponse
+from app.services.job_creation_state import JobCreationStatus
 
 
 class TestLoadJobResult:
@@ -333,5 +335,173 @@ class TestGenerateMarpReport:
         with pytest.raises(HTTPException) as exc_info:
             await generate_marp_report(request)
 
+        assert exc_info.value.status_code == 500
+        assert "internal server error" in str(exc_info.value.detail).lower()
+
+
+class TestGetMarpReportByJobId:
+    """Test get_marp_report_by_job_id endpoint."""
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.marp_report_endpoints.job_state_manager")
+    @patch("app.api.v1.marp_report_endpoints.jinja_env")
+    async def test_get_marp_report_by_job_id_success(
+        self, mock_jinja_env: MagicMock, mock_state_manager: MagicMock
+    ):
+        """Test successful retrieval of completed job's Marp report."""
+        from datetime import datetime
+
+        # Setup mock job status with completed state
+        mock_status = JobCreationStatus(
+            job_id="test-job-123",
+            status="completed",
+            progress=100,
+            start_time=datetime.now(),
+            result={
+                "status": "failed",
+                "error_message": "Job generation did not complete successfully.",
+                "infeasible_tasks": [{"task_id": "task_1", "task_name": "Test Task"}],
+                "requirement_relaxation_suggestions": [
+                    {
+                        "relaxation_type": "automation_level_reduction",
+                        "original_requirement": "Original task",
+                        "relaxed_requirement": "Relaxed task",
+                        "feasibility_after_relaxation": "High",
+                        "recommendation_level": "Highly Recommended",
+                    }
+                ],
+                "job_id": "test-job-123",
+            },
+        )
+
+        # Mock async method
+        mock_state_manager.get_status_async = AsyncMock(return_value=mock_status)
+
+        # Mock template rendering
+        mock_template = MagicMock()
+        mock_template.render.return_value = "---\nmarp: true\n---\n# Test Report"
+        mock_jinja_env.get_template.return_value = mock_template
+
+        result = await get_marp_report_by_job_id("test-job-123")
+
+        # Verify async method was called
+        mock_state_manager.get_status_async.assert_called_once_with("test-job-123")
+
+        # Verify response
+        assert result.job_id == "test-job-123"
+        assert result.markdown == "---\nmarp: true\n---\n# Test Report"
+        assert result.slide_count > 0
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.marp_report_endpoints.job_state_manager")
+    async def test_get_marp_report_by_job_id_not_found(
+        self, mock_state_manager: MagicMock
+    ):
+        """Test 404 error with improved message when job not found."""
+        # Mock async method returning None (job not found)
+        mock_state_manager.get_status_async = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_marp_report_by_job_id("nonexistent-job-id")
+
+        # Verify async method was called
+        mock_state_manager.get_status_async.assert_called_once_with("nonexistent-job-id")
+
+        # Verify error response
+        assert exc_info.value.status_code == 404
+        assert "Job not found or expired" in str(exc_info.value.detail)
+        assert "24 hours" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.marp_report_endpoints.job_state_manager")
+    async def test_get_marp_report_by_job_id_not_completed(
+        self, mock_state_manager: MagicMock
+    ):
+        """Test 400 error when job is not yet completed."""
+        from datetime import datetime
+
+        # Setup mock job status with 'creating' state
+        mock_status = JobCreationStatus(
+            job_id="in-progress-job",
+            status="creating",
+            progress=50,
+            start_time=datetime.now(),
+        )
+
+        mock_state_manager.get_status_async = AsyncMock(return_value=mock_status)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_marp_report_by_job_id("in-progress-job")
+
+        # Verify async method was called
+        mock_state_manager.get_status_async.assert_called_once_with("in-progress-job")
+
+        # Verify error response
+        assert exc_info.value.status_code == 400
+        assert "not completed" in str(exc_info.value.detail).lower()
+        assert "creating" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.marp_report_endpoints.job_state_manager")
+    async def test_get_marp_report_by_job_id_no_result(
+        self, mock_state_manager: MagicMock
+    ):
+        """Test 404 error when job completed but has no result data."""
+        from datetime import datetime
+
+        # Setup mock job status with completed state but no result
+        mock_status = JobCreationStatus(
+            job_id="job-no-result",
+            status="completed",
+            progress=100,
+            start_time=datetime.now(),
+            result=None,  # No result available
+        )
+
+        mock_state_manager.get_status_async = AsyncMock(return_value=mock_status)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_marp_report_by_job_id("job-no-result")
+
+        # Verify async method was called
+        mock_state_manager.get_status_async.assert_called_once_with("job-no-result")
+
+        # Verify error response
+        assert exc_info.value.status_code == 404
+        assert "job-no-result" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    @patch("app.api.v1.marp_report_endpoints.job_state_manager")
+    @patch("app.api.v1.marp_report_endpoints.jinja_env")
+    async def test_get_marp_report_by_job_id_template_error(
+        self, mock_jinja_env: MagicMock, mock_state_manager: MagicMock
+    ):
+        """Test 500 error when template rendering fails."""
+        from datetime import datetime
+
+        # Setup mock job status with completed state
+        mock_status = JobCreationStatus(
+            job_id="job-template-error",
+            status="completed",
+            progress=100,
+            start_time=datetime.now(),
+            result={
+                "status": "failed",
+                "infeasible_tasks": [],
+                "requirement_relaxation_suggestions": [],
+            },
+        )
+
+        mock_state_manager.get_status_async = AsyncMock(return_value=mock_status)
+
+        # Mock template to raise exception
+        mock_template = MagicMock()
+        mock_template.render.side_effect = Exception("Template rendering failed")
+        mock_jinja_env.get_template.return_value = mock_template
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_marp_report_by_job_id("job-template-error")
+
+        # Verify error response
         assert exc_info.value.status_code == 500
         assert "internal server error" in str(exc_info.value.detail).lower()


### PR DESCRIPTION
## Summary

- `GET /v1/marp-report/{job_id}` エンドポイントで `JobCreationStateManager` の非同期メソッドを使用するように変更
- 404エラーメッセージを改善: `"Job not found or expired. Job results are kept for 24 hours."`
- DEBUGログを追加して404ケースの可観測性を向上

## Changes

### Implementation
- `expertAgent/app/api/v1/marp_report_endpoints.py`
  - Line 290: `get_status()` → `await get_status_async()` に変更
  - Line 293-295: エラーメッセージ改善 + DEBUGログ追加

### Tests
- `expertAgent/tests/unit/test_marp_report_endpoints.py`
  - 5つの新規テストケース追加:
    - `test_get_marp_report_by_job_id_success`
    - `test_get_marp_report_by_job_id_not_found`
    - `test_get_marp_report_by_job_id_not_completed`
    - `test_get_marp_report_by_job_id_no_result`
    - `test_get_marp_report_by_job_id_template_error`

## Quality Metrics

| Metric | Target | Actual |
|--------|--------|--------|
| Coverage | 90%+ | **94.31%** |
| Unit Tests | All pass | **26/26** |
| Ruff | 0 errors | **0** |
| MyPy | 0 errors | **0** |

## Test Plan

- [x] 単体テスト全パス (26/26)
- [x] カバレッジ 90%以上達成 (94.31%)
- [x] 静的解析エラーゼロ (Ruff/MyPy)
- [x] 実践的APIテスト: 404エラーメッセージ確認
- [x] DEBUGログ出力確認
- [x] 非同期キャッシュフロー確認 (L1/L2)

## Related Issues

- Closes #240
- Parent: #193
- Related: #239 (Valkey統合)
- Follow-up: #244 (main.pyでValkey接続初期化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)