### PR TITLE
feat(expertAgent): Valkey 初期化の myVault 対応 (#252)

### DIFF
--- a/expertAgent/app/api/v1/ab_test_endpoints.py
+++ b/expertAgent/app/api/v1/ab_test_endpoints.py
@@ -27,7 +27,7 @@ from app.services.ab_test_service import (
     ABTestService,
     ABTestServiceError,
 )
-from core.config import settings
+from core.secrets import secrets_manager
 
 logger = logging.getLogger(__name__)
 
@@ -38,14 +38,29 @@ _ab_test_service: ABTestService | None = None
 
 
 def get_ab_test_service() -> ABTestService:
-    """Get or create the shared ABTestService instance."""
+    """Get or create the shared ABTestService instance.
+
+    Uses secrets_manager.get_connection_config() for myVault priority (Issue #252).
+    """
     global _ab_test_service
     if _ab_test_service is None:
+        valkey_host = secrets_manager.get_connection_config(
+            "VALKEY_HOST", value_type=str, default="localhost"
+        )
+        valkey_port = secrets_manager.get_connection_config(
+            "VALKEY_PORT", value_type=int, default=6379
+        )
+        valkey_db = secrets_manager.get_connection_config(
+            "VALKEY_DB", value_type=int, default=0
+        )
+        valkey_enabled = secrets_manager.get_connection_config(
+            "VALKEY_ENABLED", value_type=bool, default=False
+        )
         _ab_test_service = ABTestService(
-            valkey_host=settings.VALKEY_HOST,
-            valkey_port=settings.VALKEY_PORT,
-            valkey_db=settings.VALKEY_DB,
-            use_valkey=settings.VALKEY_ENABLED,
+            valkey_host=valkey_host,
+            valkey_port=valkey_port,
+            valkey_db=valkey_db,
+            use_valkey=valkey_enabled,
         )
     return _ab_test_service
 

--- a/expertAgent/app/api/v1/diagnostic_endpoints.py
+++ b/expertAgent/app/api/v1/diagnostic_endpoints.py
@@ -19,7 +19,7 @@ from app.services.conversation_service import ConversationService
 from app.services.index_manager import IndexManager
 from app.services.valkey_client import ValkeyClient, ValkeyConnectionError
 from app.stores.conversation_store_valkey import ConversationStoreValkey
-from core.config import settings
+from core.secrets import secrets_manager
 
 logger = logging.getLogger(__name__)
 
@@ -29,16 +29,24 @@ router = APIRouter(prefix="/chat/diagnostics", tags=["Diagnostics"])
 async def get_conversation_service() -> ConversationService:
     """Dependency to get ConversationService instance.
 
+    Uses secrets_manager.get_connection_config() for myVault priority (Issue #252).
+
     Returns:
         ConversationService instance with connected store and index manager
 
     Raises:
         HTTPException: If unable to connect to Valkey
     """
-    # Get Valkey connection settings
-    valkey_host = getattr(settings, "VALKEY_HOST", "localhost")
-    valkey_port = getattr(settings, "VALKEY_PORT", 6379)
-    valkey_db = getattr(settings, "VALKEY_DB", 0)
+    # Get Valkey connection settings via secrets_manager
+    valkey_host = secrets_manager.get_connection_config(
+        "VALKEY_HOST", value_type=str, default="localhost"
+    )
+    valkey_port = secrets_manager.get_connection_config(
+        "VALKEY_PORT", value_type=int, default=6379
+    )
+    valkey_db = secrets_manager.get_connection_config(
+        "VALKEY_DB", value_type=int, default=0
+    )
 
     try:
         # Create and connect store
@@ -58,8 +66,10 @@ async def get_conversation_service() -> ConversationService:
         await valkey_client.connect()
         index_manager = IndexManager(valkey_client)
 
-        # Create service
-        langfuse_host = getattr(settings, "LANGFUSE_HOST", "http://localhost:3000")
+        # Create service - also use secrets_manager for LANGFUSE_HOST
+        langfuse_host = secrets_manager.get_connection_config(
+            "LANGFUSE_HOST", value_type=str, default="http://localhost:3000"
+        )
         service = ConversationService(
             store=store,
             index_manager=index_manager,

--- a/expertAgent/app/main.py
+++ b/expertAgent/app/main.py
@@ -29,8 +29,8 @@ from app.api.v1 import (
 from app.middleware import MethodValidatorMiddleware, ResponseValidatorMiddleware
 from app.services.job_creation_state import job_state_manager
 from app.services.valkey_client import ValkeyClient
-from core.config import settings
 from core.logger import setup_logging
+from core.secrets import secrets_manager
 
 logger = logging.getLogger(__name__)
 
@@ -41,17 +41,33 @@ async def lifespan(app: FastAPI):
     # Startup: Initialize logging
     setup_logging()
 
-    # Initialize Valkey connection for JobCreationStateManager (Issue #244)
-    if settings.VALKEY_ENABLED:
-        logger.info(
-            f"Initializing Valkey connection: {settings.VALKEY_HOST}:{settings.VALKEY_PORT}"
+    # Initialize Valkey connection for JobCreationStateManager (Issue #244, #252)
+    # Use secrets_manager.get_connection_config() for myVault priority with env fallback
+    valkey_enabled = secrets_manager.get_connection_config(
+        "VALKEY_ENABLED", value_type=bool, default=False
+    )
+
+    if valkey_enabled:
+        valkey_host = secrets_manager.get_connection_config(
+            "VALKEY_HOST", value_type=str, default="localhost"
         )
+        valkey_port = secrets_manager.get_connection_config(
+            "VALKEY_PORT", value_type=int, default=6379
+        )
+        valkey_db = secrets_manager.get_connection_config(
+            "VALKEY_DB", value_type=int, default=0
+        )
+        valkey_ttl = secrets_manager.get_connection_config(
+            "VALKEY_TTL", value_type=int, default=86400
+        )
+
+        logger.info(f"Initializing Valkey connection: {valkey_host}:{valkey_port}")
         valkey_client = ValkeyClient(
-            host=settings.VALKEY_HOST,
-            port=settings.VALKEY_PORT,
-            db=settings.VALKEY_DB,
+            host=valkey_host,
+            port=valkey_port,
+            db=valkey_db,
         )
-        job_state_manager.configure_valkey(valkey_client, settings.VALKEY_TTL)
+        job_state_manager.configure_valkey(valkey_client, valkey_ttl)
         await job_state_manager.connect_valkey()
     else:
         logger.info("Valkey disabled - JobCreationStateManager using L1 cache only")
@@ -59,7 +75,7 @@ async def lifespan(app: FastAPI):
     yield
 
     # Shutdown: cleanup Valkey connection
-    if settings.VALKEY_ENABLED:
+    if valkey_enabled:
         await job_state_manager.disconnect_valkey()
 
 
@@ -201,13 +217,16 @@ async def health_check() -> dict[str, Any]:
     """Health check endpoint (used by CI/CD).
 
     Returns:
-        Health status including Valkey connection state (Issue #244)
+        Health status including Valkey connection state (Issue #244, #252)
     """
+    valkey_enabled = secrets_manager.get_connection_config(
+        "VALKEY_ENABLED", value_type=bool, default=False
+    )
     return {
         "status": "healthy",
         "service": "expertAgent",
         "valkey": {
-            "enabled": settings.VALKEY_ENABLED,
+            "enabled": valkey_enabled,
             "connected": job_state_manager.is_valkey_connected,
         },
     }

--- a/expertAgent/app/services/metrics_aggregation_service.py
+++ b/expertAgent/app/services/metrics_aggregation_service.py
@@ -22,7 +22,7 @@ from app.schemas.observability import (
 )
 from app.services.trace_service import trace_service
 from app.services.valkey_client import ValkeyClient, ValkeyConnectionError
-from core.config import settings
+from core.secrets import secrets_manager
 
 from .base import BaseService
 from .response_builder import ResponseBuilder
@@ -37,13 +37,20 @@ class MetricsAggregationService(BaseService):
     """Service for aggregating requirement definition metrics."""
 
     def __init__(self) -> None:
-        """Initialize MetricsAggregationService."""
+        """Initialize MetricsAggregationService.
+
+        Uses secrets_manager.get_connection_config() for myVault priority (Issue #252).
+        """
         super().__init__(logger=logger, response_builder=ResponseBuilder())
-        self._use_valkey = settings.VALKEY_ENABLED
+        self._use_valkey = secrets_manager.get_connection_config(
+            "VALKEY_ENABLED", value_type=bool, default=False
+        )
         self._valkey_client: ValkeyClient | None = None
 
     async def _get_valkey_client(self) -> ValkeyClient | None:
         """Get or create Valkey client connection.
+
+        Uses secrets_manager.get_connection_config() for myVault priority (Issue #252).
 
         Returns:
             ValkeyClient if available, None otherwise.
@@ -53,10 +60,19 @@ class MetricsAggregationService(BaseService):
 
         if self._valkey_client is None:
             try:
+                valkey_host = secrets_manager.get_connection_config(
+                    "VALKEY_HOST", value_type=str, default="localhost"
+                )
+                valkey_port = secrets_manager.get_connection_config(
+                    "VALKEY_PORT", value_type=int, default=6379
+                )
+                valkey_db = secrets_manager.get_connection_config(
+                    "VALKEY_DB", value_type=int, default=0
+                )
                 self._valkey_client = ValkeyClient(
-                    host=settings.VALKEY_HOST,
-                    port=settings.VALKEY_PORT,
-                    db=settings.VALKEY_DB,
+                    host=valkey_host,
+                    port=valkey_port,
+                    db=valkey_db,
                 )
                 await self._valkey_client.connect()
             except ValkeyConnectionError as e:

--- a/expertAgent/tests/conftest.py
+++ b/expertAgent/tests/conftest.py
@@ -26,8 +26,28 @@ def enable_myvault_for_ci():
         # Create a mock MyVault client
         mock_client = MagicMock()
 
-        # Configure mock responses
-        mock_client.get_secret.return_value = "mock-secret-value"
+        # Configure mock responses with type-appropriate values
+        # get_secret returns values that can be converted to expected types
+        # Note: myvault_client.get_secret(project, key) - project is first arg
+        def mock_get_secret(project, key):
+            """Return type-appropriate mock values for each key."""
+            mock_values = {
+                # Valkey configuration (Issue #252)
+                "VALKEY_ENABLED": "false",  # Disable Valkey in tests
+                "VALKEY_HOST": "localhost",
+                "VALKEY_PORT": "6379",
+                "VALKEY_DB": "0",
+                "VALKEY_TTL": "86400",
+                # Langfuse configuration
+                "LANGFUSE_HOST": "http://localhost:3000",
+                # API keys
+                "OPENAI_API_KEY": "mock-openai-key",
+                "GOOGLE_API_KEY": "mock-google-key",
+                "ANTHROPIC_API_KEY": "mock-anthropic-key",
+            }
+            return mock_values.get(key, "mock-secret-value")
+
+        mock_client.get_secret.side_effect = mock_get_secret
         mock_client.get_secrets.return_value = {
             "OPENAI_API_KEY": "mock-openai-key",
             "GOOGLE_API_KEY": "mock-google-key",
@@ -35,6 +55,7 @@ def enable_myvault_for_ci():
         }
         mock_client.update_secret.return_value = None
         mock_client.health_check.return_value = True
+        mock_client.get_default_project.return_value = "expertagent"
 
         # Set the mock client
         secrets_manager.myvault_client = mock_client

--- a/expertAgent/tests/unit/test_diagnostic_endpoints.py
+++ b/expertAgent/tests/unit/test_diagnostic_endpoints.py
@@ -276,9 +276,25 @@ class TestGetConversationService:
         # Import ValkeyConnectionError for the test
         from app.services.valkey_client import ValkeyConnectionError
 
-        with patch(
-            "app.api.v1.diagnostic_endpoints.ConversationStoreValkey"
-        ) as mock_store_class:
+        def get_config_side_effect(key, **kwargs):
+            config_map = {
+                "VALKEY_HOST": "localhost",
+                "VALKEY_PORT": 6379,
+                "VALKEY_DB": 0,
+                "LANGFUSE_HOST": "http://localhost:3000",
+            }
+            return config_map.get(key, kwargs.get("default"))
+
+        with (
+            patch(
+                "app.api.v1.diagnostic_endpoints.secrets_manager"
+            ) as mock_secrets,
+            patch(
+                "app.api.v1.diagnostic_endpoints.ConversationStoreValkey"
+            ) as mock_store_class,
+        ):
+            mock_secrets.get_connection_config.side_effect = get_config_side_effect
+
             mock_store = MagicMock()
             mock_store.connect = AsyncMock(
                 side_effect=ValkeyConnectionError("Connection refused")
@@ -312,13 +328,32 @@ class TestGetConversationServiceSuccess:
     @pytest.mark.unit
     async def test_get_conversation_service_success(self):
         """Test successful service creation."""
-        with patch(
-            "app.api.v1.diagnostic_endpoints.ConversationStoreValkey"
-        ) as mock_store_class, patch(
-            "app.api.v1.diagnostic_endpoints.ValkeyClient"
-        ) as mock_client_class, patch(
-            "app.api.v1.diagnostic_endpoints.IndexManager"
-        ) as mock_index_class:
+
+        def get_config_side_effect(key, **kwargs):
+            config_map = {
+                "VALKEY_HOST": "localhost",
+                "VALKEY_PORT": 6379,
+                "VALKEY_DB": 0,
+                "LANGFUSE_HOST": "http://localhost:3000",
+            }
+            return config_map.get(key, kwargs.get("default"))
+
+        with (
+            patch(
+                "app.api.v1.diagnostic_endpoints.secrets_manager"
+            ) as mock_secrets,
+            patch(
+                "app.api.v1.diagnostic_endpoints.ConversationStoreValkey"
+            ) as mock_store_class,
+            patch(
+                "app.api.v1.diagnostic_endpoints.ValkeyClient"
+            ) as mock_client_class,
+            patch(
+                "app.api.v1.diagnostic_endpoints.IndexManager"
+            ) as mock_index_class,
+        ):
+            mock_secrets.get_connection_config.side_effect = get_config_side_effect
+
             # Set up mocks
             mock_store = MagicMock()
             mock_store.connect = AsyncMock()

--- a/expertAgent/tests/unit/test_issue_244_main_lifespan.py
+++ b/expertAgent/tests/unit/test_issue_244_main_lifespan.py
@@ -119,11 +119,14 @@ class TestHealthEndpoint:
     @pytest.mark.unit
     async def test_health_includes_valkey_status_when_enabled(self) -> None:
         """Test /health returns Valkey status when enabled."""
-        # Patch settings and job_state_manager
-        with patch("app.main.settings") as mock_settings, patch(
-            "app.main.job_state_manager"
-        ) as mock_manager:
-            mock_settings.VALKEY_ENABLED = True
+        # Patch secrets_manager and job_state_manager
+        with (
+            patch(
+                "app.main.secrets_manager.get_connection_config"
+            ) as mock_get_config,
+            patch("app.main.job_state_manager") as mock_manager,
+        ):
+            mock_get_config.return_value = True
             mock_manager.is_valkey_connected = True
 
             # Import app after patching
@@ -144,10 +147,13 @@ class TestHealthEndpoint:
     @pytest.mark.unit
     async def test_health_includes_valkey_status_when_disabled(self) -> None:
         """Test /health returns Valkey status when disabled."""
-        with patch("app.main.settings") as mock_settings, patch(
-            "app.main.job_state_manager"
-        ) as mock_manager:
-            mock_settings.VALKEY_ENABLED = False
+        with (
+            patch(
+                "app.main.secrets_manager.get_connection_config"
+            ) as mock_get_config,
+            patch("app.main.job_state_manager") as mock_manager,
+        ):
+            mock_get_config.return_value = False
             mock_manager.is_valkey_connected = False
 
             from app.main import app
@@ -172,16 +178,27 @@ class TestLifespanValkeyInit:
         mock_valkey_client = MagicMock()
         mock_valkey_client.connect = AsyncMock()
 
-        with patch("app.main.settings") as mock_settings, patch(
-            "app.main.ValkeyClient", return_value=mock_valkey_client
-        ) as mock_valkey_class, patch(
-            "app.main.job_state_manager"
-        ) as mock_manager:
-            mock_settings.VALKEY_ENABLED = True
-            mock_settings.VALKEY_HOST = "localhost"
-            mock_settings.VALKEY_PORT = 6379
-            mock_settings.VALKEY_DB = 0
-            mock_settings.VALKEY_TTL = 86400
+        def get_config_side_effect(key, **kwargs):
+            config_map = {
+                "VALKEY_ENABLED": True,
+                "VALKEY_HOST": "localhost",
+                "VALKEY_PORT": 6379,
+                "VALKEY_DB": 0,
+                "VALKEY_TTL": 86400,
+            }
+            return config_map.get(key, kwargs.get("default"))
+
+        with (
+            patch(
+                "app.main.secrets_manager.get_connection_config"
+            ) as mock_get_config,
+            patch(
+                "app.main.ValkeyClient", return_value=mock_valkey_client
+            ) as mock_valkey_class,
+            patch("app.main.job_state_manager") as mock_manager,
+            patch("app.main.setup_logging"),
+        ):
+            mock_get_config.side_effect = get_config_side_effect
             mock_manager.configure_valkey = MagicMock()
             mock_manager.connect_valkey = AsyncMock()
             mock_manager.disconnect_valkey = AsyncMock()
@@ -209,12 +226,15 @@ class TestLifespanValkeyInit:
     @pytest.mark.unit
     async def test_lifespan_skips_valkey_when_disabled(self) -> None:
         """Test lifespan skips Valkey when VALKEY_ENABLED=false."""
-        with patch("app.main.settings") as mock_settings, patch(
-            "app.main.ValkeyClient"
-        ) as mock_valkey_class, patch(
-            "app.main.job_state_manager"
-        ) as mock_manager:
-            mock_settings.VALKEY_ENABLED = False
+        with (
+            patch(
+                "app.main.secrets_manager.get_connection_config"
+            ) as mock_get_config,
+            patch("app.main.ValkeyClient") as mock_valkey_class,
+            patch("app.main.job_state_manager") as mock_manager,
+            patch("app.main.setup_logging"),
+        ):
+            mock_get_config.return_value = False
             mock_manager.configure_valkey = MagicMock()
             mock_manager.connect_valkey = AsyncMock()
             mock_manager.disconnect_valkey = AsyncMock()
@@ -236,10 +256,15 @@ class TestLifespanValkeyInit:
     @pytest.mark.unit
     async def test_lifespan_logs_valkey_disabled_message(self) -> None:
         """Test lifespan logs message when Valkey is disabled."""
-        with patch("app.main.settings") as mock_settings, patch(
-            "app.main.job_state_manager"
-        ) as mock_manager, patch("app.main.logger") as mock_logger:
-            mock_settings.VALKEY_ENABLED = False
+        with (
+            patch(
+                "app.main.secrets_manager.get_connection_config"
+            ) as mock_get_config,
+            patch("app.main.job_state_manager") as mock_manager,
+            patch("app.main.logger") as mock_logger,
+            patch("app.main.setup_logging"),
+        ):
+            mock_get_config.return_value = False
             mock_manager.configure_valkey = MagicMock()
             mock_manager.connect_valkey = AsyncMock()
             mock_manager.disconnect_valkey = AsyncMock()

--- a/expertAgent/tests/unit/test_metrics_aggregation_service.py
+++ b/expertAgent/tests/unit/test_metrics_aggregation_service.py
@@ -103,7 +103,11 @@ def create_sample_sessions() -> list[dict[str, Any]]:
 @pytest.fixture
 def metrics_service():
     """Create MetricsAggregationService instance."""
-    return MetricsAggregationService()
+    with patch(
+        "app.services.metrics_aggregation_service.secrets_manager"
+    ) as mock_secrets:
+        mock_secrets.get_connection_config.return_value = False
+        return MetricsAggregationService()
 
 
 @pytest.fixture
@@ -545,24 +549,31 @@ class TestValkeyCache:
         metrics_service._use_valkey = True
         metrics_service._valkey_client = None
 
-        with patch(
-            "app.services.metrics_aggregation_service.ValkeyClient"
-        ) as MockValkeyClient:
+        def get_config_side_effect(key, **kwargs):
+            config_map = {
+                "VALKEY_HOST": "localhost",
+                "VALKEY_PORT": 6379,
+                "VALKEY_DB": 0,
+            }
+            return config_map.get(key, kwargs.get("default"))
+
+        with (
+            patch(
+                "app.services.metrics_aggregation_service.ValkeyClient"
+            ) as MockValkeyClient,
+            patch(
+                "app.services.metrics_aggregation_service.secrets_manager"
+            ) as mock_secrets,
+        ):
+            mock_secrets.get_connection_config.side_effect = get_config_side_effect
             mock_client = MagicMock()
             mock_client.connect = AsyncMock()
             MockValkeyClient.return_value = mock_client
 
-            with patch(
-                "app.services.metrics_aggregation_service.settings"
-            ) as mock_settings:
-                mock_settings.VALKEY_HOST = "localhost"
-                mock_settings.VALKEY_PORT = 6379
-                mock_settings.VALKEY_DB = 0
+            result = await metrics_service._get_valkey_client()
 
-                result = await metrics_service._get_valkey_client()
-
-                assert result == mock_client
-                mock_client.connect.assert_awaited_once()
+            assert result == mock_client
+            mock_client.connect.assert_awaited_once()
 
     @pytest.mark.unit
     async def test_valkey_connection_error_returns_none(
@@ -574,26 +585,33 @@ class TestValkeyCache:
         metrics_service._use_valkey = True
         metrics_service._valkey_client = None
 
-        with patch(
-            "app.services.metrics_aggregation_service.ValkeyClient"
-        ) as MockValkeyClient:
+        def get_config_side_effect(key, **kwargs):
+            config_map = {
+                "VALKEY_HOST": "localhost",
+                "VALKEY_PORT": 6379,
+                "VALKEY_DB": 0,
+            }
+            return config_map.get(key, kwargs.get("default"))
+
+        with (
+            patch(
+                "app.services.metrics_aggregation_service.ValkeyClient"
+            ) as MockValkeyClient,
+            patch(
+                "app.services.metrics_aggregation_service.secrets_manager"
+            ) as mock_secrets,
+        ):
+            mock_secrets.get_connection_config.side_effect = get_config_side_effect
             mock_client = MagicMock()
             mock_client.connect = AsyncMock(
                 side_effect=ValkeyConnectionError("Connection failed")
             )
             MockValkeyClient.return_value = mock_client
 
-            with patch(
-                "app.services.metrics_aggregation_service.settings"
-            ) as mock_settings:
-                mock_settings.VALKEY_HOST = "localhost"
-                mock_settings.VALKEY_PORT = 6379
-                mock_settings.VALKEY_DB = 0
+            result = await metrics_service._get_valkey_client()
 
-                result = await metrics_service._get_valkey_client()
-
-                assert result is None
-                assert metrics_service._valkey_client is None
+            assert result is None
+            assert metrics_service._valkey_client is None
 
     @pytest.mark.unit
     async def test_valkey_cache_store(self, metrics_service: MetricsAggregationService):

--- a/expertAgent/tests/unit/test_valkey_myvault_integration.py
+++ b/expertAgent/tests/unit/test_valkey_myvault_integration.py
@@ -1,0 +1,453 @@
+"""Tests for Valkey myVault integration (Issue #252).
+
+Verifies that Valkey configuration is retrieved via secrets_manager.get_connection_config()
+with myVault priority and environment variable fallback.
+"""
+
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestValkeyMyVaultIntegration:
+    """Test suite for Valkey myVault integration."""
+
+    # ========================================
+    # main.py - lifespan Valkey initialization
+    # ========================================
+
+    def test_main_imports_secrets_manager(self) -> None:
+        """main.py should import secrets_manager."""
+        # Clear cached modules
+        modules_to_clear = [
+            key for key in sys.modules.keys() if key.startswith("app.main")
+        ]
+        for mod in modules_to_clear:
+            del sys.modules[mod]
+
+        from app import main
+
+        # Check that secrets_manager is imported and available
+        assert hasattr(main, "secrets_manager")
+
+    @pytest.mark.asyncio
+    async def test_main_lifespan_uses_get_connection_config_when_disabled(
+        self,
+    ) -> None:
+        """Lifespan should use get_connection_config and not connect when disabled."""
+        with (
+            patch(
+                "app.main.secrets_manager.get_connection_config"
+            ) as mock_get_config,
+            patch("app.main.job_state_manager"),
+            patch("app.main.ValkeyClient") as mock_valkey,
+            patch("app.main.setup_logging"),
+        ):
+            # Configure mock to return False for VALKEY_ENABLED
+            mock_get_config.return_value = False
+
+            from app.main import lifespan
+
+            # Create a mock app
+            mock_app = MagicMock()
+
+            # Run the lifespan
+            async with lifespan(mock_app):
+                pass
+
+            # Verify get_connection_config was called for VALKEY_ENABLED
+            mock_get_config.assert_called()
+            calls = [call[0][0] for call in mock_get_config.call_args_list]
+            assert "VALKEY_ENABLED" in calls
+
+            # ValkeyClient should not be instantiated when disabled
+            mock_valkey.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_main_lifespan_uses_get_connection_config_when_enabled(self) -> None:
+        """Lifespan should use get_connection_config for all Valkey settings."""
+        with (
+            patch(
+                "app.main.secrets_manager.get_connection_config"
+            ) as mock_get_config,
+            patch("app.main.job_state_manager") as mock_state_mgr,
+            patch("app.main.ValkeyClient") as mock_valkey,
+            patch("app.main.setup_logging"),
+        ):
+            # Configure mock to return values based on key
+            def get_config_side_effect(key: str, **kwargs: Any) -> Any:
+                config_map = {
+                    "VALKEY_ENABLED": True,
+                    "VALKEY_HOST": "test-host",
+                    "VALKEY_PORT": 6380,
+                    "VALKEY_DB": 1,
+                    "VALKEY_TTL": 7200,
+                }
+                return config_map.get(key, kwargs.get("default"))
+
+            mock_get_config.side_effect = get_config_side_effect
+
+            # Mock async methods
+            mock_state_mgr.connect_valkey = AsyncMock()
+            mock_state_mgr.disconnect_valkey = AsyncMock()
+
+            from app.main import lifespan
+
+            # Create a mock app
+            mock_app = MagicMock()
+
+            # Run the lifespan
+            async with lifespan(mock_app):
+                pass
+
+            # Verify get_connection_config was called for all config keys
+            calls = [call[0][0] for call in mock_get_config.call_args_list]
+            assert "VALKEY_ENABLED" in calls
+            assert "VALKEY_HOST" in calls
+            assert "VALKEY_PORT" in calls
+            assert "VALKEY_DB" in calls
+            assert "VALKEY_TTL" in calls
+
+            # ValkeyClient should be instantiated with correct values
+            mock_valkey.assert_called_once_with(
+                host="test-host",
+                port=6380,
+                db=1,
+            )
+
+    # ========================================
+    # ab_test_endpoints.py - get_ab_test_service
+    # ========================================
+
+    def test_ab_test_endpoints_imports_secrets_manager(self) -> None:
+        """ab_test_endpoints.py should import secrets_manager."""
+        from app.api.v1 import ab_test_endpoints
+
+        assert hasattr(ab_test_endpoints, "secrets_manager")
+
+    def test_ab_test_endpoints_uses_get_connection_config(self) -> None:
+        """ab_test_endpoints.py should use get_connection_config for Valkey settings."""
+        with (
+            patch(
+                "app.api.v1.ab_test_endpoints.secrets_manager"
+            ) as mock_secrets,
+            patch("app.api.v1.ab_test_endpoints.ABTestService") as mock_service,
+        ):
+
+            def get_config_side_effect(key: str, **kwargs: Any) -> Any:
+                config_map = {
+                    "VALKEY_ENABLED": True,
+                    "VALKEY_HOST": "ab-test-host",
+                    "VALKEY_PORT": 6381,
+                    "VALKEY_DB": 2,
+                }
+                return config_map.get(key, kwargs.get("default"))
+
+            mock_secrets.get_connection_config.side_effect = get_config_side_effect
+
+            # Reset the singleton for testing
+            import app.api.v1.ab_test_endpoints as ab_test_module
+
+            ab_test_module._ab_test_service = None
+
+            # Get the service
+            ab_test_module.get_ab_test_service()
+
+            # Verify get_connection_config was called for each config
+            calls = mock_secrets.get_connection_config.call_args_list
+            call_keys = [call[0][0] for call in calls]
+            assert "VALKEY_HOST" in call_keys
+            assert "VALKEY_PORT" in call_keys
+            assert "VALKEY_DB" in call_keys
+            assert "VALKEY_ENABLED" in call_keys
+
+            # Verify ABTestService was called with correct values
+            mock_service.assert_called_once_with(
+                valkey_host="ab-test-host",
+                valkey_port=6381,
+                valkey_db=2,
+                use_valkey=True,
+            )
+
+    # ========================================
+    # diagnostic_endpoints.py - get_conversation_service
+    # ========================================
+
+    def test_diagnostic_endpoints_imports_secrets_manager(self) -> None:
+        """diagnostic_endpoints.py should import secrets_manager."""
+        from app.api.v1 import diagnostic_endpoints
+
+        assert hasattr(diagnostic_endpoints, "secrets_manager")
+
+    @pytest.mark.asyncio
+    async def test_diagnostic_endpoints_uses_get_connection_config(self) -> None:
+        """diagnostic_endpoints.py should use get_connection_config for Valkey settings."""
+        with (
+            patch(
+                "app.api.v1.diagnostic_endpoints.secrets_manager"
+            ) as mock_secrets,
+            patch(
+                "app.api.v1.diagnostic_endpoints.ConversationStoreValkey"
+            ) as mock_store,
+            patch("app.api.v1.diagnostic_endpoints.ValkeyClient") as mock_valkey,
+            patch("app.api.v1.diagnostic_endpoints.IndexManager"),
+            patch("app.api.v1.diagnostic_endpoints.ConversationService"),
+        ):
+
+            def get_config_side_effect(key: str, **kwargs: Any) -> Any:
+                config_map = {
+                    "VALKEY_HOST": "diagnostic-host",
+                    "VALKEY_PORT": 6382,
+                    "VALKEY_DB": 3,
+                    "LANGFUSE_HOST": "http://langfuse:3000",
+                }
+                return config_map.get(key, kwargs.get("default"))
+
+            mock_secrets.get_connection_config.side_effect = get_config_side_effect
+
+            # Mock async methods
+            mock_store_instance = MagicMock()
+            mock_store_instance.connect = AsyncMock()
+            mock_store.return_value = mock_store_instance
+
+            mock_valkey_instance = MagicMock()
+            mock_valkey_instance.connect = AsyncMock()
+            mock_valkey.return_value = mock_valkey_instance
+
+            from app.api.v1.diagnostic_endpoints import get_conversation_service
+
+            # Call the function
+            await get_conversation_service()
+
+            # Verify get_connection_config was called
+            calls = mock_secrets.get_connection_config.call_args_list
+            call_keys = [call[0][0] for call in calls]
+            assert "VALKEY_HOST" in call_keys
+            assert "VALKEY_PORT" in call_keys
+            assert "VALKEY_DB" in call_keys
+            assert "LANGFUSE_HOST" in call_keys
+
+            # Verify store and valkey client were created with correct values
+            mock_store.assert_called_once_with(
+                host="diagnostic-host",
+                port=6382,
+                db=3,
+            )
+            mock_valkey.assert_called_once_with(
+                host="diagnostic-host",
+                port=6382,
+                db=3,
+            )
+
+    # ========================================
+    # metrics_aggregation_service.py - MetricsAggregationService
+    # ========================================
+
+    def test_metrics_aggregation_service_imports_secrets_manager(self) -> None:
+        """metrics_aggregation_service.py should import secrets_manager."""
+        from app.services import metrics_aggregation_service
+
+        assert hasattr(metrics_aggregation_service, "secrets_manager")
+
+    def test_metrics_aggregation_service_code_uses_get_connection_config(self) -> None:
+        """MetricsAggregationService code should call get_connection_config."""
+        # Read the source file to verify the pattern is used
+        import inspect
+
+        from app.services.metrics_aggregation_service import MetricsAggregationService
+
+        source = inspect.getsource(MetricsAggregationService.__init__)
+
+        # Verify the code calls get_connection_config
+        assert "secrets_manager.get_connection_config" in source
+        assert "VALKEY_ENABLED" in source
+
+    def test_metrics_aggregation_service_get_valkey_client_code_uses_get_connection_config(
+        self,
+    ) -> None:
+        """MetricsAggregationService._get_valkey_client code should use get_connection_config."""
+        # Read the source file to verify the pattern is used
+        import inspect
+
+        from app.services.metrics_aggregation_service import MetricsAggregationService
+
+        source = inspect.getsource(MetricsAggregationService._get_valkey_client)
+
+        # Verify the code calls get_connection_config
+        assert "secrets_manager.get_connection_config" in source
+        assert "VALKEY_HOST" in source
+        assert "VALKEY_PORT" in source
+        assert "VALKEY_DB" in source
+
+
+class TestValkeyConfigFallback:
+    """Test environment variable fallback behavior."""
+
+    def test_fallback_to_default_when_not_found(self) -> None:
+        """Should use default value when config not found."""
+        from core.secrets import SecretsManager
+
+        with (
+            patch.object(SecretsManager, "__init__", return_value=None),
+            patch.object(SecretsManager, "_get_from_myvault", return_value=None),
+        ):
+            manager = SecretsManager.__new__(SecretsManager)
+            manager.myvault_enabled = False
+            manager.myvault_client = None
+            manager.settings = MagicMock()
+            manager.settings.VALKEY_HOST = ""  # Empty env var
+            manager._cache = {}
+            manager.cache_ttl = 300
+
+            # Should return default
+            result = manager.get_connection_config(
+                "VALKEY_HOST", value_type=str, default="fallback-host"
+            )
+            assert result == "fallback-host"
+
+    def test_type_conversion_for_port(self) -> None:
+        """Port should be converted to int."""
+        from core.secrets import SecretsManager
+
+        with (
+            patch.object(SecretsManager, "__init__", return_value=None),
+            patch.object(SecretsManager, "_get_from_myvault", return_value="6380"),
+            patch.object(
+                SecretsManager, "_validate_connection_config", return_value=None
+            ),
+        ):
+            manager = SecretsManager.__new__(SecretsManager)
+            manager.myvault_enabled = True
+            manager.myvault_client = MagicMock()
+            manager.settings = MagicMock()
+            manager._cache = {}
+            manager.cache_ttl = 300
+
+            result = manager.get_connection_config(
+                "VALKEY_PORT", value_type=int, default=6379
+            )
+            assert isinstance(result, int)
+            assert result == 6380
+
+    def test_type_conversion_for_enabled(self) -> None:
+        """VALKEY_ENABLED should be converted to bool."""
+        from core.secrets import SecretsManager
+
+        with (
+            patch.object(SecretsManager, "__init__", return_value=None),
+            patch.object(SecretsManager, "_get_from_myvault", return_value="true"),
+            patch.object(
+                SecretsManager, "_validate_connection_config", return_value=None
+            ),
+        ):
+            manager = SecretsManager.__new__(SecretsManager)
+            manager.myvault_enabled = True
+            manager.myvault_client = MagicMock()
+            manager.settings = MagicMock()
+            manager._cache = {}
+            manager.cache_ttl = 300
+
+            result = manager.get_connection_config(
+                "VALKEY_ENABLED", value_type=bool, default=False
+            )
+            assert isinstance(result, bool)
+            assert result is True
+
+
+class TestValkeyConnectionLogging:
+    """Test logging for Valkey connection configuration."""
+
+    def test_logs_myvault_source_when_available(self) -> None:
+        """Should log 'myvault' as source when value comes from myVault."""
+        with patch("core.secrets.logger") as mock_logger:
+            from core.secrets import SecretsManager
+
+            with (
+                patch.object(SecretsManager, "__init__", return_value=None),
+                patch.object(
+                    SecretsManager, "_get_from_myvault", return_value="myvault-host"
+                ),
+                patch.object(
+                    SecretsManager, "_validate_connection_config", return_value=None
+                ),
+            ):
+                manager = SecretsManager.__new__(SecretsManager)
+                manager.myvault_enabled = True
+                manager.myvault_client = MagicMock()
+                manager.settings = MagicMock()
+                manager.settings.VALKEY_HOST = ""
+                manager._cache = {}
+                manager.cache_ttl = 300
+
+                # Call get_connection_config
+                manager.get_connection_config("VALKEY_HOST", value_type=str)
+
+                # Verify logging was called with myvault source
+                mock_logger.info.assert_called()
+                log_calls = [str(call) for call in mock_logger.info.call_args_list]
+                # At least one call should mention myvault
+                assert any("myvault" in call for call in log_calls)
+
+    def test_logs_env_source_when_fallback(self) -> None:
+        """Should log 'env' as source when value comes from environment."""
+        with patch("core.secrets.logger") as mock_logger:
+            from core.secrets import SecretsManager
+
+            with (
+                patch.object(SecretsManager, "__init__", return_value=None),
+                patch.object(SecretsManager, "_get_from_myvault", return_value=None),
+                patch.object(
+                    SecretsManager, "_validate_connection_config", return_value=None
+                ),
+            ):
+                manager = SecretsManager.__new__(SecretsManager)
+                manager.myvault_enabled = True
+                manager.myvault_client = MagicMock()
+                # Create a real Settings-like object
+                mock_settings = MagicMock()
+                mock_settings.VALKEY_HOST = "env-host"
+                manager.settings = mock_settings
+                manager._cache = {}
+                manager.cache_ttl = 300
+
+                # Call get_connection_config
+                result = manager.get_connection_config("VALKEY_HOST", value_type=str)
+
+                # Value should be from env
+                assert result == "env-host"
+
+                # Verify logging was called with env source
+                mock_logger.info.assert_called()
+                log_calls = [str(call) for call in mock_logger.info.call_args_list]
+                # At least one call should mention env
+                assert any("env" in call for call in log_calls)
+
+
+class TestHealthEndpointUsesSecretsManager:
+    """Test that health endpoint uses secrets_manager."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_uses_get_connection_config(self) -> None:
+        """Health check should use secrets_manager for VALKEY_ENABLED."""
+        with (
+            patch(
+                "app.main.secrets_manager.get_connection_config"
+            ) as mock_get_config,
+            patch("app.main.job_state_manager") as mock_state_manager,
+        ):
+            mock_get_config.return_value = True
+            mock_state_manager.is_valkey_connected = True
+
+            from app.main import health_check
+
+            result = await health_check()
+
+            # Verify get_connection_config was called
+            mock_get_config.assert_called()
+
+            # Verify the response structure
+            assert result["status"] == "healthy"
+            assert result["valkey"]["enabled"] is True
+            assert result["valkey"]["connected"] is True


### PR DESCRIPTION
## Summary

- Valkey 接続設定を `settings.VALKEY_*` から `secrets_manager.get_connection_config()` に変更
- myVault 優先で設定を取得し、取得できない場合は環境変数にフォールバック
- 4つのファイルで一貫したパターンを適用

## Changes

### 実装変更
- `expertAgent/app/main.py` - lifespan での Valkey 初期化
- `expertAgent/app/api/v1/ab_test_endpoints.py` - ABTestService 初期化
- `expertAgent/app/api/v1/diagnostic_endpoints.py` - 診断エンドポイント
- `expertAgent/app/services/metrics_aggregation_service.py` - メトリクス集約サービス

### テスト追加
- `expertAgent/tests/unit/test_valkey_myvault_integration.py` - 新規 16 テスト
- `expertAgent/tests/conftest.py` - CI 用モック修正（型変換対応）

## Test plan

- [x] 単体テスト: 1501 passed (カバレッジ 83.93%)
- [x] 結合テスト: 259 passed
- [x] 静的解析: Ruff 0 errors, MyPy 0 errors
- [x] 受入テスト (ローカル):
  - [x] myVault から Valkey 設定取得を確認
  - [x] 環境変数フォールバック動作を確認
- [x] GitHub Actions CI: success

## Related Issue

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)