### PR TITLE
fix(langfuse): add MinIO bucket auto-creation on startup #265

### DIFF
--- a/docker-compose.platform.yml
+++ b/docker-compose.platform.yml
@@ -238,6 +238,29 @@ services:
       start_period: 10s
     restart: unless-stopped
 
+  # MinIO Bucket Initializer - Creates langfuse bucket on startup
+  langfuse-minio-init:
+    image: minio/mc:RELEASE.2024-11-17T19-35-25Z
+    container_name: myswiftagent-langfuse-minio-init
+    depends_on:
+      langfuse-minio:
+        condition: service_healthy
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER:-minioadmin}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-minioadmin}
+      - LANGFUSE_S3_BUCKET=${LANGFUSE_S3_EVENT_UPLOAD_BUCKET:-langfuse}
+    entrypoint: >
+      /bin/sh -c "
+      set -e;
+      echo 'Initializing MinIO bucket for Langfuse...';
+      mc alias set myminio http://langfuse-minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
+      mc mb --ignore-existing myminio/$${LANGFUSE_S3_BUCKET};
+      echo 'Bucket '$${LANGFUSE_S3_BUCKET}' created or already exists';
+      "
+    networks:
+      - myswiftagent
+    restart: "no"
+
   langfuse-worker:
     image: langfuse/langfuse-worker:3
     container_name: myswiftagent-langfuse-worker
@@ -250,6 +273,8 @@ services:
         condition: service_healthy
       langfuse-minio:
         condition: service_healthy
+      langfuse-minio-init:
+        condition: service_completed_successfully
     environment: &langfuse-env
       # Database
       DATABASE_URL: postgresql://${LANGFUSE_DB_USER:-langfuse}:${LANGFUSE_DB_PASSWORD:-langfuse}@langfuse-db:5432/${LANGFUSE_DB_NAME:-langfuse}
@@ -326,6 +351,8 @@ services:
         condition: service_healthy
       langfuse-minio:
         condition: service_healthy
+      langfuse-minio-init:
+        condition: service_completed_successfully
     environment:
       <<: *langfuse-env
 


### PR DESCRIPTION
## Summary
- Add `langfuse-minio-init` service to docker-compose.platform.yml that automatically creates the required `langfuse` bucket in MinIO on startup
- Uses `minio/mc` (MinIO Client) container as a one-shot initializer with health check dependency on `langfuse-minio`
- Fixes issue where Langfuse trace data was not being persisted due to missing bucket

## Test plan
- [x] Verified `docker compose config --quiet` passes
- [x] Verified YAML syntax and style consistency
- [x] Ran E2E test with `make dev-all` - bucket auto-created and traces persisted
- [x] All static analysis checks pass (Ruff errors: 0)

Fixes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)