### PR TITLE
fix(commonUI): resolve MyPy type errors in model_settings module

### DIFF
--- a/commonUI/core/model_settings.py
+++ b/commonUI/core/model_settings.py
@@ -95,7 +95,8 @@ class ModelSettingsLoader:
         """
         config = self._load_config()
         provider_data = config.get("providers", {}).get(provider, {})
-        return provider_data.get("models", [])
+        models: list[dict[str, Any]] = provider_data.get("models", [])
+        return models
 
     def get_model_ids(self) -> list[str]:
         """Get list of all model IDs.
@@ -113,7 +114,8 @@ class ModelSettingsLoader:
             Dictionary of category ID to category data
         """
         config = self._load_config()
-        return config.get("settings_categories", {})
+        categories: dict[str, Any] = config.get("settings_categories", {})
+        return categories
 
     def get_settings_by_category(self, category: str) -> list[dict[str, Any]]:
         """Get settings for a specific category.
@@ -126,7 +128,8 @@ class ModelSettingsLoader:
         """
         categories = self.get_settings_categories()
         category_data = categories.get(category, {})
-        return category_data.get("settings", [])
+        settings: list[dict[str, Any]] = category_data.get("settings", [])
+        return settings
 
     def get_all_settings(self) -> list[dict[str, Any]]:
         """Get all model settings across all categories.
@@ -173,7 +176,8 @@ class ModelSettingsLoader:
         """
         categories = self.get_settings_categories()
         category_data = categories.get(category, {})
-        return category_data.get("recommended_models", [])
+        recommended: list[str] = category_data.get("recommended_models", [])
+        return recommended
 
 
 # Global instance for convenience

--- a/commonUI/pages/3_🔐_MyVault.py
+++ b/commonUI/pages/3_🔐_MyVault.py
@@ -75,7 +75,7 @@ def _get_or_select_default_project() -> str | None:
     Returns:
         Selected project name or None if no projects available
     """
-    selected_project = st.session_state.myvault_selected_project
+    selected_project: str | None = st.session_state.myvault_selected_project
 
     # Auto-select default project if none is selected
     if not selected_project and st.session_state.myvault_projects:
@@ -90,8 +90,9 @@ def _get_or_select_default_project() -> str | None:
             else None,
         )
         if default_project:
-            st.session_state.myvault_selected_project = default_project["name"]
-            selected_project = default_project["name"]
+            project_name: str = default_project["name"]
+            st.session_state.myvault_selected_project = project_name
+            selected_project = project_name
 
     return selected_project
 

--- a/commonUI/tests/test_model_settings.py
+++ b/commonUI/tests/test_model_settings.py
@@ -3,6 +3,7 @@
 Issue #269: LLM model settings management via MyVault.
 """
 
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -199,7 +200,7 @@ class TestHelperFunctions:
     """Test suite for helper functions."""
 
     @pytest.fixture
-    def mock_loader(self, tmp_path: Path) -> None:
+    def mock_loader(self, tmp_path: Path) -> Generator[None, None, None]:
         """Setup mock loader."""
         config_path = tmp_path / "available_models.yaml"
         with open(config_path, "w") as f:


### PR DESCRIPTION
## Summary

- commonUI/core/model_settings.py, pages/3_🔐_MyVault.py, tests/test_model_settings.py のMyPyエラーを修正

## Changes

- dict.get()からの戻り値に明示的な型アノテーションを追加
- テストfixtureのGenerator型アノテーションを修正
- セッションステート変数に型アノテーションを追加

## Related Issue

Follow-up fix for #269 - CI failure on develop branch (MyPy errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)